### PR TITLE
🔊 logs out the full error when retrying

### DIFF
--- a/utils/grpcUtils.js
+++ b/utils/grpcUtils.js
@@ -71,7 +71,7 @@ export const withRetries = (
           operation.retry(err)
         ) {
           logger.warn(
-            `grpc method ${methodName} failed with errorCode ${err.code}, retrying after ${currentAttempt} attempt(s)`,
+            `grpc method ${methodName} failed with errorCode ${err.code}. Full error: ${err}. Retrying after ${currentAttempt} attempt(s).`,
           );
           return;
         }


### PR DESCRIPTION
- logs out the full error when retrying grpc method