### PR TITLE
includes schema errors in ClinicalSubmissionData

### DIFF
--- a/schemas/Clinical/index.js
+++ b/schemas/Clinical/index.js
@@ -276,21 +276,20 @@ const convertClinicalSubmissionDataToGql = (programShortName, data) => {
   const schemaErrors = get(data, 'schemaErrors', {});
   const fileErrors = get(data, 'fileErrors', []);
   // convert clinical entities for gql
-  const clinicalEntities = Object.entries(submission.clinicalEntities || {}).map(
-    ([clinicalType, clinicalEntity]) =>
-      convertClinicalSubmissionEntityToGql(
-        clinicalType,
-        clinicalEntity,
-        schemaErrors[clinicalType],
-      ),
-  );
 
   return {
     id: submission._id || null,
     programShortName,
     state: submission.state || null,
     version: submission.version || null,
-    clinicalEntities: clinicalEntities,
+    clinicalEntities: () =>
+      Object.entries(submission.clinicalEntities || {}).map(([clinicalType, clinicalEntity]) =>
+        convertClinicalSubmissionEntityToGql(
+          clinicalType,
+          clinicalEntity,
+          schemaErrors[clinicalType],
+        ),
+      ),
     fileErrors: fileErrors,
     schemaErrors: schemaErrors || [],
   };

--- a/schemas/Clinical/index.js
+++ b/schemas/Clinical/index.js
@@ -111,7 +111,7 @@ const typeDefs = gql`
     creator: String
     records: [ClinicalSubmissionRecord]!
     stats: ClinicalSubmissionStats
-    dataErrors: [ClinicalSubmissionError]!
+    dataErrors: [ClinicalSubmissionDataError]!
     schemaErrors: [ClinicalSubmissionSchemaError]!
     dataUpdates: [ClinicalSubmissionUpdate]!
     createdAt: DateTime
@@ -143,7 +143,7 @@ const typeDefs = gql`
     donorId: String!
   }
 
-  type ClinicalSubmissionError implements ClinicalEntityError @cost(complexity: 5) {
+  type ClinicalSubmissionDataError implements ClinicalEntityError @cost(complexity: 5) {
     type: String!
     message: String!
     row: Int!

--- a/schemas/Clinical/index.js
+++ b/schemas/Clinical/index.js
@@ -152,7 +152,7 @@ const typeDefs = gql`
     donorId: String!
   }
 
-  type ClinicalSubmissionSchemaError implements ClinicalEntityError {
+  type ClinicalSubmissionSchemaError implements ClinicalEntityError @cost(complexity: 10) {
     type: String!
     message: String!
     row: Int!

--- a/schemas/Clinical/index.js
+++ b/schemas/Clinical/index.js
@@ -95,6 +95,7 @@ const typeDefs = gql`
     version: String
     clinicalEntities: [ClinicalEntityData]!
     fileErrors: [ClinicalError]
+    schemaErrors: [ClinicalSubmissionError]!
   }
 
   type ClinicalError @cost(complexity: 5) {
@@ -291,6 +292,7 @@ const convertClinicalSubmissionDataToGql = (programShortName, data) => {
     version: submission.version || null,
     clinicalEntities: clinicalEntities,
     fileErrors: fileErrors,
+    schemaErrors: schemaErrors || [],
   };
 };
 


### PR DESCRIPTION
- includes schema errors in ClinicalSubmissionData
- creates `ClinicalEntityError` gql interface that is implemented by `ClinicalSubmissionError`
and `ClinicalSubmissionSchemaError`. `ClinicalSubmissionSchemaError` needs to have a `clinicalType` attached