### PR TITLE
🐛 fixes the wrong place to look for clinicalEntities

### DIFF
--- a/schemas/Clinical/index.js
+++ b/schemas/Clinical/index.js
@@ -307,7 +307,7 @@ const convertClinicalSubmissionDataToGql = (programShortName, data) => {
   const submission = get(data, 'submission', {});
   const schemaErrors = get(data, 'schemaErrors', {});
   const fileErrors = get(data, 'fileErrors', []);
-  const clinicalEntities = get(data, 'clinicalEntities', {});
+  const clinicalEntities = get(submission, 'clinicalEntities', {});
 
   return {
     id: submission._id || null,

--- a/schemas/Clinical/index.js
+++ b/schemas/Clinical/index.js
@@ -316,9 +316,10 @@ const convertClinicalSubmissionDataToGql = (programShortName, data) => {
     version: submission.version || null,
     clinicalEntities: async () => {
       const clinicalSubmissionTypeList = await clinicalService.getClinicalSubmissionTypesList();
-      const filledClinicalEntities = clinicalSubmissionTypeList.map(
-        clinicalType => clinicalEntities[clinicalType] || { clinicalType },
-      );
+      const filledClinicalEntities = clinicalSubmissionTypeList.map(clinicalType => ({
+        clinicalType,
+        ...(clinicalEntities[clinicalType] || {}),
+      }));
       return filledClinicalEntities.map(clinicalEntity =>
         convertClinicalSubmissionEntityToGql(
           clinicalEntity.clinicalType,


### PR DESCRIPTION
two problems:
1) was looking in wrong place for `clinicalEntities`
2) did not include `clinicalType` in the clinicalEntity when it is not empty