### PR TITLE
updates Ego api to match with latest release

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-  "javascript.validate.enable": false,
-  "flow.useNPMPackagedFlow": true,
-  "flow.runOnAllFiles": true,
-  "flow.runOnEdit": true
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -834,6 +834,15 @@
         "@types/node": "*"
       }
     },
+    "@types/bytebuffer": {
+      "version": "5.0.40",
+      "resolved": "https://registry.npmjs.org/@types/bytebuffer/-/bytebuffer-5.0.40.tgz",
+      "integrity": "sha512-h48dyzZrPMz25K6Q4+NCwWaxwXany2FhQg/ErOcdZS1ZpsaDnDMZg8JYLMTGz7uvXKrcKGJUZJlZObyfgdaN9g==",
+      "requires": {
+        "@types/long": "*",
+        "@types/node": "*"
+      }
+    },
     "@types/connect": {
       "version": "3.4.32",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.32.tgz",
@@ -3155,14 +3164,15 @@
       }
     },
     "grpc": {
-      "version": "1.20.3",
-      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.20.3.tgz",
-      "integrity": "sha512-GsEsi0NVj6usS/xor8pF/xDbDiwZQR59aZl5NUZ59Sy2bdPQFZ3UePr5wevZjHboirRCIQCKRI1cCgvSWUe2ag==",
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.24.2.tgz",
+      "integrity": "sha512-EG3WH6AWMVvAiV15d+lr+K77HJ/KV/3FvMpjKjulXHbTwgDZkhkcWbwhxFAoTdxTkQvy0WFcO3Nog50QBbHZWw==",
       "requires": {
+        "@types/bytebuffer": "^5.0.40",
         "lodash.camelcase": "^4.3.0",
         "lodash.clone": "^4.5.0",
         "nan": "^2.13.2",
-        "node-pre-gyp": "^0.13.0",
+        "node-pre-gyp": "^0.14.0",
         "protobufjs": "^5.0.3"
       },
       "dependencies": {
@@ -3199,7 +3209,7 @@
           }
         },
         "chownr": {
-          "version": "1.1.1",
+          "version": "1.1.3",
           "bundled": true
         },
         "code-point-at": {
@@ -3218,6 +3228,13 @@
           "version": "1.0.2",
           "bundled": true
         },
+        "debug": {
+          "version": "3.2.6",
+          "bundled": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
         "deep-extend": {
           "version": "0.6.0",
           "bundled": true
@@ -3231,10 +3248,10 @@
           "bundled": true
         },
         "fs-minipass": {
-          "version": "1.2.5",
+          "version": "1.2.7",
           "bundled": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "^2.6.0"
           }
         },
         "fs.realpath": {
@@ -3255,19 +3272,31 @@
             "wide-align": "^1.1.0"
           }
         },
+        "glob": {
+          "version": "7.1.4",
+          "bundled": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
         "has-unicode": {
           "version": "2.0.1",
           "bundled": true
         },
         "iconv-lite": {
-          "version": "0.4.23",
+          "version": "0.4.24",
           "bundled": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
           }
         },
         "ignore-walk": {
-          "version": "3.0.1",
+          "version": "3.0.3",
           "bundled": true,
           "requires": {
             "minimatch": "^3.0.4"
@@ -3282,7 +3311,7 @@
           }
         },
         "inherits": {
-          "version": "2.0.3",
+          "version": "2.0.4",
           "bundled": true
         },
         "ini": {
@@ -3312,7 +3341,7 @@
           "bundled": true
         },
         "minipass": {
-          "version": "2.3.5",
+          "version": "2.9.0",
           "bundled": true,
           "requires": {
             "safe-buffer": "^5.1.2",
@@ -3320,10 +3349,10 @@
           }
         },
         "minizlib": {
-          "version": "1.2.1",
+          "version": "1.3.3",
           "bundled": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "^2.9.0"
           }
         },
         "mkdirp": {
@@ -3339,30 +3368,21 @@
             }
           }
         },
+        "ms": {
+          "version": "2.1.2",
+          "bundled": true
+        },
         "needle": {
-          "version": "2.3.1",
+          "version": "2.4.0",
           "bundled": true,
           "requires": {
-            "debug": "^4.1.0",
+            "debug": "^3.2.6",
             "iconv-lite": "^0.4.4",
             "sax": "^1.2.4"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "4.1.1",
-              "bundled": true,
-              "requires": {
-                "ms": "^2.1.1"
-              }
-            },
-            "ms": {
-              "version": "2.1.1",
-              "bundled": true
-            }
           }
         },
         "node-pre-gyp": {
-          "version": "0.13.0",
+          "version": "0.14.0",
           "bundled": true,
           "requires": {
             "detect-libc": "^1.0.2",
@@ -3374,7 +3394,7 @@
             "rc": "^1.2.7",
             "rimraf": "^2.6.1",
             "semver": "^5.3.0",
-            "tar": "^4"
+            "tar": "^4.4.2"
           }
         },
         "nopt": {
@@ -3390,7 +3410,7 @@
           "bundled": true
         },
         "npm-packlist": {
-          "version": "1.4.1",
+          "version": "1.4.6",
           "bundled": true,
           "requires": {
             "ignore-walk": "^3.0.1",
@@ -3443,7 +3463,7 @@
           "bundled": true
         },
         "process-nextick-args": {
-          "version": "2.0.0",
+          "version": "2.0.1",
           "bundled": true
         },
         "protobufjs": {
@@ -3481,24 +3501,10 @@
           }
         },
         "rimraf": {
-          "version": "2.6.3",
+          "version": "2.7.1",
           "bundled": true,
           "requires": {
             "glob": "^7.1.3"
-          },
-          "dependencies": {
-            "glob": {
-              "version": "7.1.3",
-              "bundled": true,
-              "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-              }
-            }
           }
         },
         "safe-buffer": {
@@ -3514,7 +3520,7 @@
           "bundled": true
         },
         "semver": {
-          "version": "5.7.0",
+          "version": "5.7.1",
           "bundled": true
         },
         "set-blocking": {
@@ -3553,16 +3559,16 @@
           "bundled": true
         },
         "tar": {
-          "version": "4.4.8",
+          "version": "4.4.13",
           "bundled": true,
           "requires": {
             "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.4",
-            "minizlib": "^1.1.1",
+            "minipass": "^2.8.6",
+            "minizlib": "^1.2.1",
             "mkdirp": "^0.5.0",
             "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.2"
+            "yallist": "^3.0.3"
           }
         },
         "util-deprecate": {
@@ -3581,7 +3587,7 @@
           "bundled": true
         },
         "yallist": {
-          "version": "3.0.3",
+          "version": "3.1.1",
           "bundled": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "graphql": "^14.5.4",
     "graphql-cost-analysis": "^1.0.3",
     "graphql-tools": "^4.0.4",
-    "grpc": "^1.20.3",
+    "grpc": "^1.24.2",
     "lodash": "^4.17.14",
     "node-fetch": "^2.3.0",
     "retry": "^0.12.0",

--- a/schemas/User/index.js
+++ b/schemas/User/index.js
@@ -126,7 +126,7 @@ const resolvers = {
 
       // a user should have only one key
       if (keys.length === 1) {
-        const { accessToken, exp } = keys[0];
+        const { apiKey: accessToken, exp } = keys[0];
         apiKey = { key: accessToken, exp: exp, error: '' };
       } else {
         const errorMsg = 'An error has been found with your API key. Please generate a new API key';
@@ -146,12 +146,15 @@ const resolvers = {
       // delete old keys
       const keys = await egoService.getEgoAccessKeys(userId, Authorization);
       const deletions = await egoService.deleteKeys(keys, Authorization);
-
       // get scopes for new token
       const { scopes } = await egoService.getScopes(userName, Authorization);
 
       const response = await egoService.generateEgoAccessKey(userId, scopes, Authorization);
-      return { exp: response.exp, key: response.accessToken, error: '' };
+      return {
+        exp: response.exp,
+        key: response.apiKey,
+        error: '',
+      };
     },
   },
 };

--- a/services/ego/index.js
+++ b/services/ego/index.js
@@ -79,7 +79,7 @@ const getEgoAccessKeys = async (userId, Authorization) => {
  * @param {string} userId
  * @param {Array<string>} scopes
  * @param {string} Authorization
- * @returns {Array<EgoAccessKeyResponse>}
+ * @returns {Promise<EgoAccessKeyResponse>}
  */
 const generateEgoAccessKey = async (userId, scopes, Authorization) => {
   const url = urlJoin(


### PR DESCRIPTION
- updates ego according to these changes here: https://github.com/overture-stack/ego/pull/420
- adds some [JSDoc](https://www.typescriptlang.org/docs/handbook/type-checking-javascript-files.html#supported-jsdoc) to provide type info (I think we should do more of this in the gateway, it's not perfect but better than nothing if we're not getting the luxury of TypeScript)