### PR TITLE
fix null value not being checked correctly

### DIFF
--- a/schemas/Clinical/index.js
+++ b/schemas/Clinical/index.js
@@ -387,7 +387,7 @@ const convertClinicalSubmissionDataErrorToGql = errorData => {
     donorId: get(errorData, 'info.donorSubmitterId', ''),
 
     // errorData.info.value may come back as null if not provided in uploaded file
-    value: get(errorData, 'info.value', ''),
+    value: get(errorData, 'info.value', '') || '',
   };
 };
 

--- a/schemas/Clinical/index.js
+++ b/schemas/Clinical/index.js
@@ -384,7 +384,7 @@ const convertClinicalSubmissionDataErrorToGql = errorData => {
     message: errorData.message,
     row: errorData.index,
     field: errorData.fieldName,
-    donorId: get(errorData, 'info.donorSubmitterId', ''),
+    donorId: get(errorData, 'info.donorSubmitterId', '') || '',
 
     // errorData.info.value may come back as null if not provided in uploaded file
     value: get(errorData, 'info.value', '') || '',


### PR DESCRIPTION
**Description of changes**

`null` was being returned by GQL for `value`, but it was reporting other fields as being null.

**Type of Change**

- [X] Bug
- [ ] Styling
- [ ] New Feature
