### PR TITLE
Add Topic Permission checking to Kafka endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "server",
-  "version": "3.12.0",
+  "version": "3.13.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1223,9 +1223,9 @@
       }
     },
     "@icgc-argo/ego-token-utils": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@icgc-argo/ego-token-utils/-/ego-token-utils-8.0.0.tgz",
-      "integrity": "sha512-sgBHslKS3TnSSCNcdOpwrophLRrZitVpnussv4iRD0VKn6OFCfR32AXn+Ri9LF6KifS3FsE1WtvAYNJx1Ewz7g==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@icgc-argo/ego-token-utils/-/ego-token-utils-8.1.0.tgz",
+      "integrity": "sha512-7uGfLmEZxgRvRlh6sDYGXRJUXYRjvPPz5edP/iAM/cUiVxDry/dCdjGo/fCyT29KmIpxFJmS4Ekcp2Fw6PaOUA==",
       "requires": {
         "jsonwebtoken": "^8.5.1"
       }
@@ -10790,9 +10790,9 @@
       },
       "dependencies": {
         "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@babel/register": "^7.4.0",
     "@elastic/elasticsearch": "^7.6.1",
     "@grpc/proto-loader": "^0.5.0",
-    "@icgc-argo/ego-token-utils": "^8.0.0",
+    "@icgc-argo/ego-token-utils": "^8.1.0",
     "@icgc-argo/program-service-proto": "0.1.0",
     "@types/async-retry": "^1.4.2",
     "@types/graphql-upload": "^8.0.3",

--- a/src/app.ts
+++ b/src/app.ts
@@ -25,7 +25,7 @@ import userSchema from './schemas/User';
 import programSchema from './schemas/Program';
 import path from 'path';
 import clinicalProxyRoute from './routes/clinical-proxy';
-import kafkaProxyRoute from './routes/kafka-rest-proxy';
+import createKafkaRouter from './routes/kafka-rest-proxy';
 import createDonorAggregatorRouter from 'routes/donor-aggregator-api';
 import createFileStorageApi from './routes/file-storage-api';
 import {
@@ -149,7 +149,7 @@ const init = async () => {
     res.json(version);
   });
 
-  app.use('/kafka', kafkaProxyRoute);
+  app.use('/kafka', createKafkaRouter(egoClient));
   app.use('/clinical', clinicalProxyRoute);
   app.use('/file-centric-tsv', await createFileCentricTsvRoute(esClient));
   app.use('/donor-aggregator', createDonorAggregatorRouter(egoClient))

--- a/src/routes/file-storage-api/handlers/downloadHandler.ts
+++ b/src/routes/file-storage-api/handlers/downloadHandler.ts
@@ -20,7 +20,7 @@ const downloadHandler = ({
   rootPath: string;
   esClient: Client;
   proxyMiddlewareFactory: typeof createProxyMiddleware;
-}): Handler => async (req: AuthenticatedRequest<{ fileObjectId: string }>, res, next) => {
+}): Handler => async (req: AuthenticatedRequest, res, next) => {
   const { fileObjectId } = req.params;
   const esFileObject = await getEsFileDocumentByObjectId(esClient)(fileObjectId);
 
@@ -30,11 +30,11 @@ const downloadHandler = ({
 
   const isAuthorized =
     hasSufficientProgramMembershipAccess({
-      scopes: req.userScopes,
+      scopes: req.auth.scopes,
       file: esFileObject,
     }) &&
     hasSufficientDacoAccess({
-      scopes: req.userScopes,
+      scopes: req.auth.scopes,
       file: esFileObject,
     });
 
@@ -51,7 +51,7 @@ const downloadHandler = ({
     });
     handleRequest(req, res, next);
   } else {
-    res.status(req.authenticated ? 403 : 401).end();
+    res.status(req.auth.authenticated ? 403 : 401).end();
   }
 };
 

--- a/src/routes/file-storage-api/handlers/entitiesHandler.ts
+++ b/src/routes/file-storage-api/handlers/entitiesHandler.ts
@@ -92,11 +92,8 @@ const getAccessControlFilter = (
 };
 
 const createEntitiesHandler = ({ esClient }: { esClient: Client }): Handler => {
-  return async (
-    req: AuthenticatedRequest<{}, any, any, RequestBodyQuery>,
-    res: Response<EntitiesPageResponseBody>,
-  ) => {
-    const userScopes = req.userScopes;
+  return async (req: AuthenticatedRequest, res: Response<EntitiesPageResponseBody>) => {
+    const userScopes = req.auth.scopes;
     const serializedUserScopes = userScopes.map(egoTokenUtils.serializeScope);
     const programMembershipAccessLevel = egoTokenUtils.getProgramMembershipAccessLevel({
       permissions: serializedUserScopes,
@@ -106,12 +103,13 @@ const createEntitiesHandler = ({ esClient }: { esClient: Client }): Handler => {
       page: Number(req.query.page || 0),
       size: Number(req.query.size || 10),
       access: req.query.access,
-      fields: req.query.fields
-        ? req.query.fields
-            .split(',')
-            .map(str => str.trim())
-            .filter(_.identity)
-        : [],
+      fields: req.query.fields,
+      // TODO: removing this processing from here, we don't at this stage know that fields will be a string or an array
+      // ? req.query.fields
+      //     .split(',')
+      //     .map(str => str.trim())
+      //     .filter(_.identity)
+      // : [],
       fileName: req.query.fileName || undefined,
       id: req.query.id || undefined,
       analysisId: req.query.analysisId || undefined,
@@ -130,24 +128,35 @@ const createEntitiesHandler = ({ esClient }: { esClient: Client }): Handler => {
       .query(
         esb
           .boolQuery()
+          // TODO: All of the `as string` casting in this section was added to silence the typescript compiler, it needs to be tested
+          // the solution is likely in the types being applied to the Request object, such that it doesnt know if the query params are string or parsed into arrays
           .must([
             parsedRequestQuery.id
-              ? esb.termsQuery(FILE_METADATA_FIELDS['object_id'], parsedRequestQuery.id)
+              ? esb.termsQuery(FILE_METADATA_FIELDS['object_id'], parsedRequestQuery.id as string)
               : emptyFilter(),
             parsedRequestQuery.fileName
-              ? esb.termsQuery(FILE_METADATA_FIELDS['file.name'], parsedRequestQuery.fileName)
+              ? esb.termsQuery(
+                  FILE_METADATA_FIELDS['file.name'],
+                  parsedRequestQuery.fileName as string,
+                )
               : emptyFilter(),
             parsedRequestQuery.access
-              ? esb.termsQuery(FILE_METADATA_FIELDS['file_access'], parsedRequestQuery.access)
+              ? esb.termsQuery(
+                  FILE_METADATA_FIELDS['file_access'],
+                  parsedRequestQuery.access as string,
+                )
               : emptyFilter(),
             parsedRequestQuery.analysisId
               ? esb.termsQuery(
                   FILE_METADATA_FIELDS['analysis.analysis_id'],
-                  parsedRequestQuery.analysisId,
+                  parsedRequestQuery.analysisId as string,
                 )
               : emptyFilter(),
             parsedRequestQuery.projectCode
-              ? esb.termsQuery(FILE_METADATA_FIELDS['study_id'], parsedRequestQuery.projectCode)
+              ? esb.termsQuery(
+                  FILE_METADATA_FIELDS['study_id'],
+                  parsedRequestQuery.projectCode as string,
+                )
               : emptyFilter(),
             accessControlFilter,
           ]),
@@ -164,7 +173,9 @@ const createEntitiesHandler = ({ esClient }: { esClient: Client }): Handler => {
       .map(file =>
         parsedRequestQuery.fields.length
           ? (Object.fromEntries(
-              Object.entries(file).filter(([key]) => parsedRequestQuery.fields.includes(key)),
+              Object.entries(file).filter(([key]) =>
+                (parsedRequestQuery.fields as string).includes(key),
+              ),
             ) as Partial<SongEntity>)
           : file,
       );

--- a/src/routes/file-storage-api/handlers/entitiesIdHandler.ts
+++ b/src/routes/file-storage-api/handlers/entitiesIdHandler.ts
@@ -6,16 +6,16 @@ import { hasSufficientProgramMembershipAccess } from 'routes/utils/accessValidat
 import { getEsFileDocumentByObjectId, toSongEntity } from '../utils';
 
 const createEntitiesIdHandler = ({ esClient }: { esClient: Client }): Handler => {
-  return async (req: AuthenticatedRequest<{ fileObjectId: string }>, res, next) => {
+  return async (req: AuthenticatedRequest, res, next) => {
     const file = await getEsFileDocumentByObjectId(esClient)(req.params.fileObjectId);
     const isAuthorized = hasSufficientProgramMembershipAccess({
-      scopes: req.userScopes,
+      scopes: req.auth.scopes,
       file,
     });
     if (isAuthorized) {
       res.status(200).send(toSongEntity(file as EsFileCentricDocument));
     } else {
-      res.status(req.authenticated ? 403 : 401).end();
+      res.status(req.auth.authenticated ? 403 : 401).end();
     }
   };
 };

--- a/src/routes/kafka-rest-proxy.ts
+++ b/src/routes/kafka-rest-proxy.ts
@@ -22,61 +22,73 @@ import urlJoin from 'url-join';
 import logger from '../utils/logger';
 import fetch from 'node-fetch';
 import { json } from 'body-parser';
-import express from 'express';
+import express, { Router } from 'express';
+import { EgoClient } from 'services/ego';
+import authenticatedRequestMiddleware, {
+  AuthenticatedRequest,
+} from 'routes/middleware/authenticatedRequestMiddleware';
 import egoTokenUtils from 'utils/egoTokenUtils';
 
-var router = express.Router();
-const apiRoot = KAFKA_REST_PROXY_ROOT;
+const createKafkaRouter = (egoClient: EgoClient): Router => {
+  const router = express.Router();
+  const apiRoot = KAFKA_REST_PROXY_ROOT;
 
-// fetch needs to use the json body parser
-router.use(json());
+  // fetch needs to use the json body parser
+  router.use(json());
 
-// middleware to secure the kafka proxy endpoint
-// it expects a valid jwt
-router.use((req, res, next) => {
-  const jwt = (req.headers.authorization || '').split(' ')[1] || '';
-  if (jwt === '') {
-    return res.status(401).send({
-      message: 'this endpoint needs a valid jwt token',
+  router.use(authenticatedRequestMiddleware({ egoClient }));
+
+  router.post('/:topic', async (req: AuthenticatedRequest, res) => {
+    const {
+      auth: { authenticated, serializedScopes, egoJwt },
+      params: { topic },
+    } = req;
+
+    // Require auth
+    if (!authenticated) {
+      res.status(401).json({ error: 'invalid auth token' });
+      return;
+    }
+
+    // Require kafka topic writing permisison
+    const hasPermission = egoTokenUtils.canWriteKafkaTopic({
+      permissions: serializedScopes,
+      topic,
     });
-  }
+    if (!hasPermission) {
+      res.status(403).json({ error: 'not authorized' });
+    }
 
-  if (!egoTokenUtils.isValidJwt(jwt)) {
-    return res.status(401).send({
-      message: 'expired token',
+    const url = urlJoin(apiRoot, 'topics', topic);
+    const msg = req.body;
+    logger.debug(`received message in kafka proxy ${JSON.stringify(msg)}`);
+    const kafkaRestProxyBody = JSON.stringify({
+      records: [
+        {
+          value: msg,
+        },
+      ],
     });
-  }
-  return next();
-});
-
-router.post('/:topic', async (req, res) => {
-  const url = urlJoin(apiRoot, 'topics', req.params.topic);
-  const msg = req.body;
-  logger.debug(`received message in kafka proxy ${JSON.stringify(msg)}`);
-  const kafkaRestProxyBody = JSON.stringify({
-    records: [
-      {
-        value: msg,
+    return fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/vnd.kafka.json.v2+json',
+        Accept: 'application/vnd.kafka.v2+json',
       },
-    ],
-  });
-  return fetch(url, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/vnd.kafka.json.v2+json',
-      Accept: 'application/vnd.kafka.v2+json',
-    },
-    body: kafkaRestProxyBody,
-  })
-    .then(response => {
-      res.contentType('application/vnd.kafka.v2+json');
-      res.status(response.status);
-      return response.body.pipe(res);
+      body: kafkaRestProxyBody,
     })
-    .catch(e => {
-      logger.error('failed to send message to kafka proxy' + e);
-      return res.status(500).send(e);
-    });
-});
+      .then(response => {
+        res.contentType('application/vnd.kafka.v2+json');
+        res.status(response.status);
+        return response.body.pipe(res);
+      })
+      .catch(e => {
+        logger.error('failed to send message to kafka proxy' + e);
+        return res.status(500).send(e);
+      });
+  });
 
-export default router;
+  return router;
+};
+
+export default createKafkaRouter;

--- a/src/routes/middleware/authenticatedRequestMiddleware.ts
+++ b/src/routes/middleware/authenticatedRequestMiddleware.ts
@@ -21,30 +21,38 @@ import { Handler, Request } from 'express';
 import egoTokenUtils from 'utils/egoTokenUtils';
 import { EgoClient } from 'services/ego';
 import { PermissionScopeObj } from '@icgc-argo/ego-token-utils';
-import logger from 'utils/logger';
 
-export type AuthenticatedRequest<Params = {}, T1 = any, T2 = any, Query = {}> = Request<
-  Params,
-  T1,
-  T2,
-  Query
-> & { userScopes: PermissionScopeObj[]; authenticated: boolean; egoJwt: string };
+type AuthRequestProperties = {
+  scopes: PermissionScopeObj[];
+  serializedScopes: string[];
+  authenticated: boolean;
+  egoJwt: string;
+};
+export type AuthenticatedRequest = Request & { auth: AuthRequestProperties };
 
 const extractUserScopes = async (config: {
   authHeader?: string;
   egoClient: EgoClient;
-}): Promise<{ scopes: string[]; authenticated: boolean; egoJwt: string }> => {
+}): Promise<AuthRequestProperties> => {
   const { authHeader, egoClient } = config;
   if (authHeader) {
     const token = authHeader.replace('Bearer ', '');
+    const unauthenticatedResponse = {
+      scopes: [],
+      serializedScopes: [],
+      authenticated: false,
+      egoJwt: token,
+    };
     try {
       const jwtData = egoTokenUtils.decodeToken(token);
       const valid = egoTokenUtils.isValidJwt(token);
       if (!valid) {
-        return { scopes: [], authenticated: false, egoJwt: token };
+        return unauthenticatedResponse;
       }
+      const scopes = jwtData.context.scope;
       return {
-        scopes: jwtData.context.scope,
+        scopes: jwtData.context.scope.map(egoTokenUtils.parseScope),
+        serializedScopes: jwtData.context.scope,
         authenticated: true,
         egoJwt: token,
       };
@@ -54,11 +62,16 @@ const extractUserScopes = async (config: {
       // If it is also not an API Key then the final .catch block will handle setting authenticated to false.
       return egoClient
         .checkApiKey({ apiKey: token })
-        .then(data => ({ scopes: data.scope as string[], authenticated: true, egoJwt: token }))
-        .catch(err => ({ scopes: [], authenticated: false, egoJwt: token }));
+        .then(data => ({
+          scopes: data.scope.map(egoTokenUtils.parseScope),
+          serializedScopes: data.scope,
+          authenticated: true,
+          egoJwt: token,
+        }))
+        .catch(err => unauthenticatedResponse);
     }
   } else {
-    return { scopes: [], authenticated: false, egoJwt: '' };
+    return { scopes: [], serializedScopes: [], authenticated: false, egoJwt: '' };
   }
 };
 
@@ -66,13 +79,11 @@ type AuthenticationMiddleware = (config: { egoClient: EgoClient }) => Handler;
 const authenticatedRequestMiddleware: AuthenticationMiddleware = ({ egoClient }) => {
   return async (req: Request, res, next) => {
     const { authorization } = req.headers;
-    const userScope = await extractUserScopes({
+    const authParams = await extractUserScopes({
       egoClient,
       authHeader: authorization,
     });
-    (req as AuthenticatedRequest).userScopes = userScope.scopes.map(egoTokenUtils.parseScope);
-    (req as AuthenticatedRequest).authenticated = userScope.authenticated;
-    (req as AuthenticatedRequest).egoJwt = userScope.egoJwt;
+    (req as AuthenticatedRequest).auth = authParams;
     next();
   };
 };

--- a/src/routes/utils/accessValidations.ts
+++ b/src/routes/utils/accessValidations.ts
@@ -30,11 +30,6 @@ import {
 } from '@icgc-argo/ego-token-utils';
 import { EGO_DACO_POLICY_NAME } from 'config';
 
-export const isDccMember = (scopes: PermissionScopeObj[]) => {
-  const serializedScopes = scopes.map(egoTokenUtils.serializeScope);
-  return egoTokenUtils.isDccMember(serializedScopes);
-};
-
 export const hasSufficientProgramMembershipAccess = (config: {
   scopes: PermissionScopeObj[];
   file?: EsFileCentricDocument;


### PR DESCRIPTION
**Description of changes**

The `/kafka/:topic` resolver is used for external applications to send messages to the DCC kafka. This PR adds permission checks to the endpoint that will require a scope which contains the topic in the policy name. The pattern checking for this scope is handled by the common validation library [icgc-argo/ego-token-utils](https://github.com/icgc-argo/ego-token-utils), with the new rules added in version [8.1.0: canWriteKafkaTopic](https://github.com/icgc-argo/ego-token-utils/pull/59) .

To achieve this, the AuthendticatedRequestMiddleware was extended to return the `serializedScopes` object (scopes as an array of strings instead of scope objects). This auth middleware was added to the kafka router and used with the validations in ego-token-utils.

Changes to the other routes using the auth middleware were also required to adopt the shape changes. For the `donor-aggregation-api` these changes were minimal, but there are complications added to the `file-storage-api`, requiring several query parameters to be cast as strings. The file storage api is behind a feature flag and not enabled anywhere, and requires additional testing before release.

**Type of Change**

- [ ] Bug
- [ ] Styling
- [x] New Feature

