### PR TITLE
feature to filter donor dashboard entries by donor id and submitter donor id

### DIFF
--- a/compose/sample_schema.json
+++ b/compose/sample_schema.json
@@ -1,6 +1,22 @@
 {
+  "settings": {
+    "index.number_of_shards": 3,
+    "index.number_of_replicas": 2,
+    "analysis": {
+      "analyzer": {
+        "whitespaceAnalyzer": {
+          "tokenizer": "whitespace",
+          "filter": ["lowercase"]
+        }
+      }
+    }
+  },
   "mappings": {
     "properties": {
+      "combinedDonorId": {
+        "type": "text",
+        "analyzer": "whitespaceAnalyzer"
+      },
       "programId": {
         "type": "keyword"
       },
@@ -11,14 +27,19 @@
         "type": "keyword"
       },
       "donorId": {
-        "type": "keyword"
+        "type": "keyword",
+        "copy_to": ["combinedDonorId"]
       },
       "submitterDonorId": {
-        "type": "keyword"
+        "type": "keyword",
+        "copy_to": ["combinedDonorId"]
       },
       "submittedCoreDataPercent": {
         "type": "scaled_float",
         "scaling_factor": 100
+      },
+      "coreCompletionDate": {
+        "type": "date"
       },
       "submittedExtendedDataPercent": {
         "type": "scaled_float",
@@ -36,6 +57,9 @@
       "publishedTumourAnalysis": {
         "type": "byte"
       },
+      "rawReadsFirstPublishedDate": {
+        "type": "date"
+      },
       "alignmentsCompleted": {
         "type": "byte"
       },
@@ -44,6 +68,21 @@
       },
       "alignmentsFailed": {
         "type": "byte"
+      },
+      "alignmentFirstPublishedDate": {
+        "type": "date"
+      },
+      "mutectCompleted": {
+        "type": "byte"
+      },
+      "mutectRunning": {
+        "type": "byte"
+      },
+      "mutectFailed": {
+        "type": "byte"
+      },
+      "mutectFirstPublishedDate": {
+        "type": "date"
       },
       "sangerVcsCompleted": {
         "type": "byte"
@@ -54,14 +93,8 @@
       "sangerVcsFailed": {
         "type": "byte"
       },
-      "mutectCompleted" : {
-        "type" : "byte"
-      },
-      "mutectFailed" : {
-        "type" : "byte"
-      },
-      "mutectRunning" : {
-        "type" : "byte"
+      "sangerVcsFirstPublishedDate": {
+        "type": "date"
       },
       "processingStatus": {
         "type": "keyword"

--- a/src/schemas/ProgramDonorSummary/gqlTypeDefs.ts
+++ b/src/schemas/ProgramDonorSummary/gqlTypeDefs.ts
@@ -36,6 +36,7 @@ export default gql`
 
   enum ProgramDonorSummaryEntryField {
     donorId
+    combinedDonorId
     validWithCurrentDictionary
     releaseStatus
     submitterDonorId

--- a/src/schemas/ProgramDonorSummary/resolvers/types.ts
+++ b/src/schemas/ProgramDonorSummary/resolvers/types.ts
@@ -59,7 +59,7 @@ export type DonorSummaryEntry = {
   createdAt: Date;
 };
 
-type ProgramDonorSummaryEntryField = keyof DonorSummaryEntry;
+type ProgramDonorSummaryEntryField = keyof DonorSummaryEntry & keyof { combinedDonorId: string };
 
 export type ProgramDonorSummaryFilter = {
   field: ProgramDonorSummaryEntryField;
@@ -105,6 +105,7 @@ export enum EsDonorDocumentField {
   alignmentsRunning = 'alignmentsRunning',
   createdAt = 'createdAt',
   donorId = 'donorId',
+  combinedDonorId = 'combinedDonorId',
   processingStatus = 'processingStatus',
   programId = 'programId',
   publishedNormalAnalysis = 'publishedNormalAnalysis',


### PR DESCRIPTION
**Description of changes**

<!-- Please add a brief description of the changes here. -->
This PR implements the feature to filter donor summary entries by partially matching donor id and submitter donor id. 
Examples: 
when querying data with the following query, if filter value is `donor`, query should return all results that contains `donor` as either donor id or submitter id. 
```
query{
  programDonorSummaryEntries (
    programShortName: "ROSI-RU",
    sorts:{
      field:donorId, order: asc
    },
    filters: [
      { 
        field: combinedDonorId,
      	values: ["donor"]
      }
    ]
  ) {
  	id
    donorId
    submitterDonorId
    programShortName
    submittedCoreDataPercent
    registeredNormalSamples
    registeredTumourSamples
    alignmentsCompleted
    alignmentsRunning
    alignmentsFailed
    sangerVcsCompleted
    sangerVcsRunning
    sangerVcsFailed
    mutectFailed
    mutectRunning
    mutectCompleted
    processingStatus
    updatedAt
    createdAt
  }
}
```

**Type of Change**

- [ ] Bug
- [x] New Feature