### PR TITLE
donor id filters accept array of values

### DIFF
--- a/src/schemas/ProgramDonorSummary/gqlTypeDefs.ts
+++ b/src/schemas/ProgramDonorSummary/gqlTypeDefs.ts
@@ -36,7 +36,14 @@ export default gql`
 
   enum ProgramDonorSummaryEntryField {
     donorId
+    """
+    use this field to filter donor entries by partially matching donorId or submitterDonorId, e.g.: "donor", "donor5"
+    """
     combinedDonorId
+    """
+    use this field to filter donor entries by 3 aggregations of submittedCoreDataPercent,
+    3 enum options to filter by: NO_DATA, COMPLETE, INCOMPLETE.
+    """
     coreDataPercentAggregation
     validWithCurrentDictionary
     releaseStatus

--- a/src/schemas/ProgramDonorSummary/resolvers/summaryEntries.ts
+++ b/src/schemas/ProgramDonorSummary/resolvers/summaryEntries.ts
@@ -71,9 +71,14 @@ const programDonorSummaryEntriesResolver: (
 
     if (field === EsDonorDocumentField.combinedDonorId && filter.values.length > 0) {
       // use wildcard query for donor_id and submitter_donor_id partial match
-      const regex = `*${filter.values[0].toLowerCase()}*`;
-      const wildcardQuery = esb.wildcardQuery(EsDonorDocumentField.combinedDonorId, regex);
-      queries.push( wildcardQuery );
+      const donorIdQueries: Query[] =[];
+      for (const value of filter.values) {
+        const regex = `*${value.toLowerCase()}*`;
+        const wildcardQuery = esb.wildcardQuery(EsDonorDocumentField.combinedDonorId, regex);
+        donorIdQueries.push(wildcardQuery);
+      }
+      const boolQuery = esb.boolQuery().should(donorIdQueries);
+      queries.push(boolQuery);
     }
 
     if (field === EsDonorDocumentField.coreDataPercentAggregation && filter.values.length > 0) {


### PR DESCRIPTION
**Description of changes**

<!-- Please add a brief description of the changes here. -->
Fix donor id filter only accepting 1 value by implementing bool should queries to allow donor id filter accept an array of values. 

**Type of Change**

- [x] Bug
- [ ] New Feature