### PR TITLE
add sample pair filter

### DIFF
--- a/src/schemas/ProgramDonorSummary/gqlTypeDefs.ts
+++ b/src/schemas/ProgramDonorSummary/gqlTypeDefs.ts
@@ -45,6 +45,12 @@ export default gql`
     3 enum options to filter by: NO_DATA, COMPLETE, INCOMPLETE.
     """
     coreDataPercentAggregation
+    """
+    use this field to filter donor entries by 2 enum values: VALID, INVALID.
+    VALID means the donor has at least 1 registered tumour/normal sample pair.
+    INVALID means the donor has not registered any tumour or normal samples.
+    """
+    registeredSamplePairs
     validWithCurrentDictionary
     releaseStatus
     submitterDonorId

--- a/src/schemas/ProgramDonorSummary/resolvers/types.ts
+++ b/src/schemas/ProgramDonorSummary/resolvers/types.ts
@@ -59,7 +59,11 @@ export type DonorSummaryEntry = {
   createdAt: Date;
 };
 
-type ProgramDonorSummaryEntryField = keyof DonorSummaryEntry & keyof { combinedDonorId: string, coreDataPercentAggregation: string };
+type ProgramDonorSummaryEntryField = keyof DonorSummaryEntry & keyof
+  { combinedDonorId: string,
+    coreDataPercentAggregation: string,
+    registeredSamplePairs: string,
+  };
 
 export type ProgramDonorSummaryFilter = {
   field: ProgramDonorSummaryEntryField;
@@ -107,6 +111,7 @@ export enum EsDonorDocumentField {
   donorId = 'donorId',
   combinedDonorId = 'combinedDonorId',
   coreDataPercentAggregation = 'coreDataPercentAggregation',
+  registeredSamplePairs = 'registeredSamplePairs',
   processingStatus = 'processingStatus',
   programId = 'programId',
   publishedNormalAnalysis = 'publishedNormalAnalysis',
@@ -161,4 +166,9 @@ export enum coreDataPercentAggregationValue {
   INCOMPLETE = 'INCOMPLETE',
   COMPLETE = 'COMPLETE',
   NO_DATA = 'NO_DATA'
+}
+
+export enum registeredSamplePairsValue {
+  VALID = 'VALID',
+  INVALID = 'INVALID',
 }


### PR DESCRIPTION
**Description of changes**

<!-- Please add a brief description of the changes here. -->

Adds a new filter field `registeredSamplePairs` to enum `ProgramDonorSummaryEntryField` for filtering donors by valid/invalid sample pairs. 

**Type of Change**

- [ ] Bug
- [x] New Feature