### PR TITLE
add list aggregation to programDonorSummary - stats API

### DIFF
--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -1,9 +1,8 @@
 # For a quick mongo/elasticSearch local enviornment
-
-version: '3'
+version: "3"
 services:
   elasticsearch:
-    image: 'elasticsearch:7.5.0'
+    image: "elasticsearch:7.5.0"
     ports:
       - 9200:9200
     volumes:
@@ -11,55 +10,14 @@ services:
     environment:
       - discovery.type=single-node
       - cluster.name=workflow.elasticsearch
-      - 'ES_JAVA_OPTS=-Xms512m -Xmx2048m'
+      - "ES_JAVA_OPTS=-Xms512m -Xmx2048m"
 
   kibana:
-    image: 'kibana:7.5.0'
+    image: "kibana:7.5.0"
     depends_on:
       - elasticsearch
     ports:
       - 5601:5601
-
-  ego-db:
-    image: '${POSTGRES_IMAGE}'
-    environment:
-      PGPORT: 5432
-      POSTGRES_DB: ego
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: password
-    volumes:
-      - 'ego_postgresql_data:/egodb'
-    ports:
-      - 18888:5432
-  ego-api:
-    image: '${EGO_IMAGE}'
-    depends_on:
-      - ego-db
-    volumes:
-      - ./ego_bootstrap:/ego_boostrap
-    environment:
-      SERVER_PORT: 8088
-      SERVER_MANAGEMENT_PORT: 8089
-      SPRING_PROFILES_ACTIVE: 'auth'
-      SPRING_DATASOURCE_URL: 'jdbc:postgresql://ego-db:5432/ego?stringtype=unspecified'
-      SPRING_DATASOURCE_USERNAME: postgres
-      SPRING_DATASOURCE_PASSWORD: password
-      SPRING_FLYWAY_ENABLED: 'true'
-      SERVER_SERVLET_CONTEXT_PATH: '/api'
-      SPRING_FLYWAY_LOCATIONS: 'classpath:flyway/sql,classpath:db/migration,filesystem:/ego_boostrap'
-      GOOGLE_CLIENT_CLIENTID: '${GOOGLE_CLIENT_CLIENTID}'
-      GOOGLE_CLIENT_CLIENTSECRET: '${GOOGLE_CLIENT_CLIENTSECRET}'
-    ports:
-      - 8088:8088
-      - 50052:50051
-  ego-ui:
-    image: '${EGO_UI_IMAGE}'
-    depends_on:
-      - ego-api
-    environment:
-      REACT_APP_API: 'http://localhost:8088/api'
-    ports:
-      - 3501:80
 
 volumes:
   es_data:

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -1,9 +1,9 @@
 # For a quick mongo/elasticSearch local enviornment
 
-version: "3"
+version: '3'
 services:
   elasticsearch:
-    image: "elasticsearch:7.5.0"
+    image: 'elasticsearch:7.5.0'
     ports:
       - 9200:9200
     volumes:
@@ -11,14 +11,55 @@ services:
     environment:
       - discovery.type=single-node
       - cluster.name=workflow.elasticsearch
-      - "ES_JAVA_OPTS=-Xms512m -Xmx2048m"
+      - 'ES_JAVA_OPTS=-Xms512m -Xmx2048m'
 
   kibana:
-    image: "kibana:7.5.0"
+    image: 'kibana:7.5.0'
     depends_on:
       - elasticsearch
     ports:
       - 5601:5601
+
+  ego-db:
+    image: '${POSTGRES_IMAGE}'
+    environment:
+      PGPORT: 5432
+      POSTGRES_DB: ego
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: password
+    volumes:
+      - 'ego_postgresql_data:/egodb'
+    ports:
+      - 18888:5432
+  ego-api:
+    image: '${EGO_IMAGE}'
+    depends_on:
+      - ego-db
+    volumes:
+      - ./ego_bootstrap:/ego_boostrap
+    environment:
+      SERVER_PORT: 8088
+      SERVER_MANAGEMENT_PORT: 8089
+      SPRING_PROFILES_ACTIVE: 'auth'
+      SPRING_DATASOURCE_URL: 'jdbc:postgresql://ego-db:5432/ego?stringtype=unspecified'
+      SPRING_DATASOURCE_USERNAME: postgres
+      SPRING_DATASOURCE_PASSWORD: password
+      SPRING_FLYWAY_ENABLED: 'true'
+      SERVER_SERVLET_CONTEXT_PATH: '/api'
+      SPRING_FLYWAY_LOCATIONS: 'classpath:flyway/sql,classpath:db/migration,filesystem:/ego_boostrap'
+      GOOGLE_CLIENT_CLIENTID: '${GOOGLE_CLIENT_CLIENTID}'
+      GOOGLE_CLIENT_CLIENTSECRET: '${GOOGLE_CLIENT_CLIENTSECRET}'
+    ports:
+      - 8088:8088
+      - 50052:50051
+  ego-ui:
+    image: '${EGO_UI_IMAGE}'
+    depends_on:
+      - ego-api
+    environment:
+      REACT_APP_API: 'http://localhost:8088/api'
+    ports:
+      - 3501:80
 
 volumes:
   es_data:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "server",
-  "version": "3.22.0",
+  "version": "3.24.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/schemas/ProgramDonorSummary/gqlTypeDefs.ts
+++ b/src/schemas/ProgramDonorSummary/gqlTypeDefs.ts
@@ -248,9 +248,6 @@ export default gql`
     Percentage of core clinical data fields submitted over total core clinical data fields
     """
     percentageCoreClinical: Float!
-    """
-
-    """
     percentageTumourAndNormal: Float!
     """
     Number of donors whose molecular data is being processed
@@ -284,7 +281,86 @@ export default gql`
     Number of donors registered to the program who currently has no released genomic file
     """
     noReleaseDonorsCount: Int!
+    """
+    Number of donors that are clinically complete at 100% core fields
+    """
+    donorsWithCompleteCoreCompletion: Int!
+    """
+    Number of donors that have incomplete core clinical fields
+    """
+    donorsWithIncompleteCoreCompletion: Int!
+    """
+    Number of donors that have no data for core clinical fields
+    """
+    donorsWithNoCoreCompletion: Int!
+    """
+    Number of donors that have at least 1 tumour/normal sample pairs
+    """
+    donorsWithValidSamplePairs: Int!
+    """
+    Number of donors that have 0 tumour or normal sample
+    """
+    donorsWithInvalidSamplePairs: Int!
 
+    """
+    Number of donors that have at least 1 tumour/normal raw reads pairs
+    """
+    donorsWithValidRawReads: Int!
+    """
+    Number of donors that have 0 tumour or normal raw read
+    """
+    donorsWithInvalidRawReads: Int!
+
+    """
+    Number of donors that have COMPLETED as alignment workflow status
+    """
+    donorsWithCompletedAlignment: Int!
+    """
+    Number of donors that have IN_PROGRESS as alignment workflow status
+    """
+    donorsWithInProgressAlignment: Int!
+    """
+    Number of donors that have FAILED as alignment workflow status
+    """
+    donorsWithFailedAlignment: Int!
+    """
+    Number of donors that have no alignment workflow status
+    """
+    donorsWithNoAlignment: Int!
+
+    """
+    Number of donors that have COMPLETED as sanger workflow status
+    """
+    donorsWithCompletedSanger: Int!
+    """
+    Number of donors that have IN_PROGRESS as sanger workflow status
+    """
+    donorsWithInProgressSanger: Int!
+    """
+    Number of donors that have FAILED as sanger workflow status
+    """
+    donorsWithFailedSanger: Int!
+    """
+    Number of donors that have no sanger workflow status
+    """
+    donorsWithNoSanger: Int!
+
+    """
+    Number of donors that have COMPLETED as mutect2 workflow status
+    """
+    donorsWithCompletedMutect: Int!
+    """
+    Number of donors that have IN_PROGRESS as mutect2 workflow status
+    """
+    donorsWithInProgressMutect: Int!
+    """
+    Number of donors that have FAILED as mutect2 workflow status
+    """
+    donorsWithFailedMutect: Int!
+    """
+    Number of donors that have no mutect2 workflow status
+    """
+    donorsWithNoMutect: Int!
     """
     Date of the most recent update to the donor summary index for this program. Can be null if no documents for this program
     """

--- a/src/schemas/ProgramDonorSummary/gqlTypeDefs.ts
+++ b/src/schemas/ProgramDonorSummary/gqlTypeDefs.ts
@@ -125,6 +125,23 @@ export default gql`
     stats: ProgramDonorSummaryStats!
   }
 
+  type WorkflowStatusCount {
+    noData: Int!
+    completed: Int!
+    inProgress: Int!
+    failed: Int!
+  }
+
+  type SamplePairsStatusCount {
+    valid: Int!
+    invalid: Int!
+  }
+
+  type CoreCompletionStatusCount {
+    completed: Int!
+    incomplete: Int!
+    noData: Int!
+  }
 
   """
   Includes status summary of clinical and molecular data processing for the given donor
@@ -281,86 +298,37 @@ export default gql`
     Number of donors registered to the program who currently has no released genomic file
     """
     noReleaseDonorsCount: Int!
-    """
-    Number of donors that are clinically complete at 100% core fields
-    """
-    donorsWithCompleteCoreCompletion: Int!
-    """
-    Number of donors that have incomplete core clinical fields
-    """
-    donorsWithIncompleteCoreCompletion: Int!
-    """
-    Number of donors that have no data for core clinical fields
-    """
-    donorsWithNoCoreCompletion: Int!
-    """
-    Number of donors that have at least 1 tumour/normal sample pairs
-    """
-    donorsWithValidSamplePairs: Int!
-    """
-    Number of donors that have 0 tumour or normal sample
-    """
-    donorsWithInvalidSamplePairs: Int!
 
     """
-    Number of donors that have at least 1 tumour/normal raw reads pairs
+    Number of donors that are clinically completed/incomplete/no core fields
     """
-    donorsWithValidRawReads: Int!
-    """
-    Number of donors that have 0 tumour or normal raw read
-    """
-    donorsWithInvalidRawReads: Int!
+    coreCompletion: CoreCompletionStatusCount!
 
     """
-    Number of donors that have COMPLETED as alignment workflow status
+    Number of donors that have VALID/INVALID sample pairs
     """
-    donorsWithCompletedAlignment: Int!
-    """
-    Number of donors that have IN_PROGRESS as alignment workflow status
-    """
-    donorsWithInProgressAlignment: Int!
-    """
-    Number of donors that have FAILED as alignment workflow status
-    """
-    donorsWithFailedAlignment: Int!
-    """
-    Number of donors that have no alignment workflow status
-    """
-    donorsWithNoAlignment: Int!
+    sampleStatus: SamplePairsStatusCount!
 
     """
-    Number of donors that have COMPLETED as sanger workflow status
+    Number of donors that have VALID/INVALID raw reads
     """
-    donorsWithCompletedSanger: Int!
-    """
-    Number of donors that have IN_PROGRESS as sanger workflow status
-    """
-    donorsWithInProgressSanger: Int!
-    """
-    Number of donors that have FAILED as sanger workflow status
-    """
-    donorsWithFailedSanger: Int!
-    """
-    Number of donors that have no sanger workflow status
-    """
-    donorsWithNoSanger: Int!
+    rawReadsStatus: SamplePairsStatusCount!
 
     """
-    Number of donors that have COMPLETED as mutect2 workflow status
+    Number of donors that have COMPLETED/IN_PROGRESS/FAILED/NO_DATA as alignment workflow status
     """
-    donorsWithCompletedMutect: Int!
+    alignmentStatusCount: WorkflowStatusCount!
+
     """
-    Number of donors that have IN_PROGRESS as mutect2 workflow status
+    Number of donors that have COMPLETED/IN_PROGRESS/FAILED/NO_DATA as Sanger VC workflow status
     """
-    donorsWithInProgressMutect: Int!
+    sangerStatusCount: WorkflowStatusCount!
+
     """
-    Number of donors that have FAILED as mutect2 workflow status
+    Number of donors that have COMPLETED/IN_PROGRESS/FAILED/NO_DATA as mutect2 workflow status
     """
-    donorsWithFailedMutect: Int!
-    """
-    Number of donors that have no mutect2 workflow status
-    """
-    donorsWithNoMutect: Int!
+    mutectStatusCount: WorkflowStatusCount!
+
     """
     Date of the most recent update to the donor summary index for this program. Can be null if no documents for this program
     """

--- a/src/schemas/ProgramDonorSummary/resolvers/SummaryStats.ts
+++ b/src/schemas/ProgramDonorSummary/resolvers/SummaryStats.ts
@@ -121,6 +121,178 @@ const programDonorSummaryStatsResolver: (
           .field(EsDonorDocumentField.validWithCurrentDictionary)
           .values([false]),
       ),
+      filterAggregation('donorsWithCompleteCoreCompletion' as AggregationName).filter(
+        esb
+          .termQuery()
+          .field(EsDonorDocumentField.submittedCoreDataPercent)
+          .value(1),
+      ),
+      filterAggregation('donorsWithIncompleteCoreCompletion' as AggregationName).filter(
+        esb
+        .rangeQuery()
+        .field(EsDonorDocumentField.submittedCoreDataPercent)
+        .gt(0)
+        .lt(1),
+      ),
+      filterAggregation('donorsWithNoCoreCompletion' as AggregationName).filter(
+        esb
+          .termQuery()
+          .field(EsDonorDocumentField.submittedCoreDataPercent)
+          .value(0),
+      ),
+      filterAggregation('donorsWithValidSamplePairs' as AggregationName).filter(
+        esb.boolQuery().must([
+          esb
+            .rangeQuery()
+            .field(EsDonorDocumentField.registeredNormalSamples)
+            .gt(0),
+          esb
+            .rangeQuery()
+            .field(EsDonorDocumentField.registeredTumourSamples)
+            .gt(0),
+        ]),
+      ),
+      filterAggregation('donorsWithInvalidSamplePairs' as AggregationName).filter(
+        esb.boolQuery().should([
+          esb
+            .rangeQuery()
+            .field(EsDonorDocumentField.registeredNormalSamples)
+            .lte(0),
+          esb
+            .rangeQuery()
+            .field(EsDonorDocumentField.registeredTumourSamples)
+            .lte(0),
+        ]),
+      ),
+      filterAggregation('donorsWithValidRawReads' as AggregationName).filter(
+        esb.boolQuery().must([
+          esb
+            .rangeQuery()
+            .field(EsDonorDocumentField.publishedNormalAnalysis)
+            .gte(1),
+          esb
+            .rangeQuery()
+            .field(EsDonorDocumentField.publishedTumourAnalysis)
+            .gte(1),
+        ]),
+      ),
+      filterAggregation('donorsWithInvalidRawReads' as AggregationName).filter(
+        esb.boolQuery().should([
+          esb
+            .rangeQuery()
+            .field(EsDonorDocumentField.publishedNormalAnalysis)
+            .lte(0),
+          esb
+            .rangeQuery()
+            .field(EsDonorDocumentField.publishedTumourAnalysis)
+            .lte(0),
+        ]),
+      ),
+      filterAggregation('donorsWithCompletedAlignment' as AggregationName).filter(
+        esb
+          .rangeQuery()
+          .field(EsDonorDocumentField.alignmentsCompleted)
+          .gte(1),
+      ),
+      filterAggregation('donorsWithInProgressAlignment' as AggregationName).filter(
+        esb
+          .rangeQuery()
+          .field(EsDonorDocumentField.alignmentsRunning)
+          .gte(1),
+      ),
+      filterAggregation('donorsWithFailedAlignment' as AggregationName).filter(
+        esb
+          .rangeQuery()
+          .field(EsDonorDocumentField.alignmentsFailed)
+          .gte(1),
+      ),
+      filterAggregation('donorsWithNoAlignment' as AggregationName).filter(
+        esb
+          .boolQuery().must([
+            esb
+            .rangeQuery()
+            .field(EsDonorDocumentField.alignmentsCompleted)
+            .lte(0),
+            esb
+            .rangeQuery()
+            .field(EsDonorDocumentField.alignmentsRunning)
+            .lte(0),
+            esb
+            .rangeQuery()
+            .field(EsDonorDocumentField.alignmentsFailed)
+            .lte(0)
+          ])
+      ),
+      filterAggregation('donorsWithCompletedSanger' as AggregationName).filter(
+        esb
+          .rangeQuery()
+          .field(EsDonorDocumentField.sangerVcsCompleted)
+          .gte(1),
+      ),
+      filterAggregation('donorsWithInProgressSanger' as AggregationName).filter(
+        esb
+          .rangeQuery()
+          .field(EsDonorDocumentField.sangerVcsRunning)
+          .gte(1),
+      ),
+      filterAggregation('donorsWithFailedSanger' as AggregationName).filter(
+        esb
+          .rangeQuery()
+          .field(EsDonorDocumentField.sangerVcsFailed)
+          .gte(1),
+      ),
+      filterAggregation('donorsWithNoSanger' as AggregationName).filter(
+        esb
+          .boolQuery().must([
+            esb
+            .rangeQuery()
+            .field(EsDonorDocumentField.sangerVcsCompleted)
+            .lte(0),
+            esb
+            .rangeQuery()
+            .field(EsDonorDocumentField.sangerVcsRunning)
+            .lte(0),
+            esb
+            .rangeQuery()
+            .field(EsDonorDocumentField.sangerVcsFailed)
+            .lte(0)
+          ])
+      ),
+      filterAggregation('donorsWithCompletedMutect' as AggregationName).filter(
+        esb
+          .rangeQuery()
+          .field(EsDonorDocumentField.mutectCompleted)
+          .gte(1),
+      ),
+      filterAggregation('donorsWithInProgressMutect' as AggregationName).filter(
+        esb
+          .rangeQuery()
+          .field(EsDonorDocumentField.mutectRunning)
+          .gte(1),
+      ),
+      filterAggregation('donorsWithFailedMutect' as AggregationName).filter(
+        esb
+          .rangeQuery()
+          .field(EsDonorDocumentField.mutectFailed)
+          .gte(1),
+      ),
+      filterAggregation('donorsWithNoMutect' as AggregationName).filter(
+        esb
+          .boolQuery().must([
+            esb
+            .rangeQuery()
+            .field(EsDonorDocumentField.mutectCompleted)
+            .lte(0),
+            esb
+            .rangeQuery()
+            .field(EsDonorDocumentField.mutectRunning)
+            .lte(0),
+            esb
+            .rangeQuery()
+            .field(EsDonorDocumentField.mutectFailed)
+            .lte(0)
+          ])
+      ),
       esb
         .sumAggregation('allFilesCount' as AggregationName)
         .field(EsDonorDocumentField.totalFilesCount),
@@ -146,6 +318,32 @@ const programDonorSummaryStatsResolver: (
       donorsWithPublishedNormalAndTumourSamples: FilterAggregationResult;
       donorsWithAllCoreClinicalData: FilterAggregationResult;
       donorsInvalidWithCurrentDictionary: FilterAggregationResult;
+
+      donorsWithCompleteCoreCompletion: FilterAggregationResult;
+      donorsWithIncompleteCoreCompletion: FilterAggregationResult;
+      donorsWithNoCoreCompletion: FilterAggregationResult;
+
+      donorsWithValidSamplePairs: FilterAggregationResult;
+      donorsWithInvalidSamplePairs: FilterAggregationResult;
+
+      donorsWithValidRawReads: FilterAggregationResult;
+      donorsWithInvalidRawReads: FilterAggregationResult;
+
+      donorsWithCompletedAlignment: FilterAggregationResult;
+      donorsWithInProgressAlignment: FilterAggregationResult;
+      donorsWithFailedAlignment: FilterAggregationResult;
+      donorsWithNoAlignment: FilterAggregationResult;
+
+      donorsWithCompletedSanger: FilterAggregationResult;
+      donorsWithInProgressSanger: FilterAggregationResult;
+      donorsWithFailedSanger: FilterAggregationResult;
+      donorsWithNoSanger: FilterAggregationResult;
+
+      donorsWithCompletedMutect: FilterAggregationResult;
+      donorsWithInProgressMutect: FilterAggregationResult;
+      donorsWithFailedMutect: FilterAggregationResult;
+      donorsWithNoMutect: FilterAggregationResult;
+
       allFilesCount: NumericAggregationResult;
       filesToQcCount: NumericAggregationResult;
       lastUpdate?: DateAggregationResult;
@@ -171,6 +369,32 @@ const programDonorSummaryStatsResolver: (
           donorsWithPublishedNormalAndTumourSamples: { doc_count: 0 },
           donorsWithAllCoreClinicalData: { doc_count: 0 },
           donorsInvalidWithCurrentDictionary: { doc_count: 0 },
+
+          donorsWithCompleteCoreCompletion: { doc_count: 0 },
+          donorsWithIncompleteCoreCompletion: { doc_count: 0 },
+          donorsWithNoCoreCompletion: { doc_count: 0 },
+
+          donorsWithValidSamplePairs: { doc_count: 0 },
+          donorsWithInvalidSamplePairs: { doc_count: 0 },
+
+          donorsWithValidRawReads: { doc_count: 0 },
+          donorsWithInvalidRawReads: { doc_count: 0 },
+
+          donorsWithCompletedAlignment: { doc_count: 0 },
+          donorsWithInProgressAlignment: { doc_count: 0 },
+          donorsWithFailedAlignment: { doc_count: 0 },
+          donorsWithNoAlignment: { doc_count: 0 },
+
+          donorsWithCompletedSanger: { doc_count: 0 },
+          donorsWithInProgressSanger: { doc_count: 0 },
+          donorsWithFailedSanger: { doc_count: 0 },
+          donorsWithNoSanger: { doc_count: 0 },
+
+          donorsWithCompletedMutect: { doc_count: 0 },
+          donorsWithInProgressMutect: { doc_count: 0 },
+          donorsWithFailedMutect: { doc_count: 0 },
+          donorsWithNoMutect: { doc_count: 0 },
+
           allFilesCount: { value: 0 },
           filesToQcCount: { value: 0 },
         },
@@ -203,6 +427,32 @@ const programDonorSummaryStatsResolver: (
     filesToQcCount: aggregations.filesToQcCount.value,
     donorsInvalidWithCurrentDictionaryCount:
       aggregations.donorsInvalidWithCurrentDictionary.doc_count,
+
+      donorsWithCompleteCoreCompletion: aggregations.donorsWithCompleteCoreCompletion.doc_count,
+      donorsWithIncompleteCoreCompletion: aggregations.donorsWithIncompleteCoreCompletion.doc_count,
+      donorsWithNoCoreCompletion: aggregations.donorsWithNoCoreCompletion.doc_count,
+
+      donorsWithValidSamplePairs: aggregations.donorsWithValidSamplePairs.doc_count,
+      donorsWithInvalidSamplePairs: aggregations.donorsWithInvalidSamplePairs.doc_count,
+
+      donorsWithValidRawReads: aggregations.donorsWithValidRawReads.doc_count,
+      donorsWithInvalidRawReads: aggregations.donorsWithInvalidRawReads.doc_count,
+
+      donorsWithCompletedAlignment: aggregations.donorsWithCompletedAlignment.doc_count,
+      donorsWithInProgressAlignment: aggregations.donorsWithInProgressAlignment.doc_count,
+      donorsWithFailedAlignment: aggregations.donorsWithFailedAlignment.doc_count,
+      donorsWithNoAlignment: aggregations.donorsWithNoAlignment.doc_count,
+
+      donorsWithCompletedSanger: aggregations.donorsWithCompletedSanger.doc_count,
+      donorsWithInProgressSanger: aggregations.donorsWithInProgressSanger.doc_count,
+      donorsWithFailedSanger: aggregations.donorsWithFailedSanger.doc_count,
+      donorsWithNoSanger: aggregations.donorsWithNoSanger.doc_count,
+
+      donorsWithCompletedMutect: aggregations.donorsWithCompletedMutect.doc_count,
+      donorsWithInProgressMutect: aggregations.donorsWithInProgressMutect.doc_count,
+      donorsWithFailedMutect: aggregations.donorsWithFailedMutect.doc_count,
+      donorsWithNoMutect: aggregations.donorsWithNoMutect.doc_count,
+
     lastUpdate: aggregations.lastUpdate?.value ? new Date(aggregations.lastUpdate.value) : undefined,
   };
 };

--- a/src/schemas/ProgramDonorSummary/resolvers/SummaryStats.ts
+++ b/src/schemas/ProgramDonorSummary/resolvers/SummaryStats.ts
@@ -121,26 +121,26 @@ const programDonorSummaryStatsResolver: (
           .field(EsDonorDocumentField.validWithCurrentDictionary)
           .values([false]),
       ),
-      filterAggregation('donorsWithCompleteCoreCompletion' as AggregationName).filter(
+      filterAggregation('completeCoreCompletion' as AggregationName).filter(
         esb
           .termQuery()
           .field(EsDonorDocumentField.submittedCoreDataPercent)
           .value(1),
       ),
-      filterAggregation('donorsWithIncompleteCoreCompletion' as AggregationName).filter(
+      filterAggregation('incompleteCoreCompletion' as AggregationName).filter(
         esb
         .rangeQuery()
         .field(EsDonorDocumentField.submittedCoreDataPercent)
         .gt(0)
         .lt(1),
       ),
-      filterAggregation('donorsWithNoCoreCompletion' as AggregationName).filter(
+      filterAggregation('noCoreCompletion' as AggregationName).filter(
         esb
           .termQuery()
           .field(EsDonorDocumentField.submittedCoreDataPercent)
           .value(0),
       ),
-      filterAggregation('donorsWithValidSamplePairs' as AggregationName).filter(
+      filterAggregation('validSamplePairs' as AggregationName).filter(
         esb.boolQuery().must([
           esb
             .rangeQuery()
@@ -152,7 +152,7 @@ const programDonorSummaryStatsResolver: (
             .gt(0),
         ]),
       ),
-      filterAggregation('donorsWithInvalidSamplePairs' as AggregationName).filter(
+      filterAggregation('invalidSamplePairs' as AggregationName).filter(
         esb.boolQuery().should([
           esb
             .rangeQuery()
@@ -164,7 +164,7 @@ const programDonorSummaryStatsResolver: (
             .lte(0),
         ]),
       ),
-      filterAggregation('donorsWithValidRawReads' as AggregationName).filter(
+      filterAggregation('validRawReads' as AggregationName).filter(
         esb.boolQuery().must([
           esb
             .rangeQuery()
@@ -176,7 +176,7 @@ const programDonorSummaryStatsResolver: (
             .gte(1),
         ]),
       ),
-      filterAggregation('donorsWithInvalidRawReads' as AggregationName).filter(
+      filterAggregation('invalidRawReads' as AggregationName).filter(
         esb.boolQuery().should([
           esb
             .rangeQuery()
@@ -188,25 +188,25 @@ const programDonorSummaryStatsResolver: (
             .lte(0),
         ]),
       ),
-      filterAggregation('donorsWithCompletedAlignment' as AggregationName).filter(
+      filterAggregation('completedAlignment' as AggregationName).filter(
         esb
           .rangeQuery()
           .field(EsDonorDocumentField.alignmentsCompleted)
           .gte(1),
       ),
-      filterAggregation('donorsWithInProgressAlignment' as AggregationName).filter(
+      filterAggregation('inProgressAlignment' as AggregationName).filter(
         esb
           .rangeQuery()
           .field(EsDonorDocumentField.alignmentsRunning)
           .gte(1),
       ),
-      filterAggregation('donorsWithFailedAlignment' as AggregationName).filter(
+      filterAggregation('failedAlignment' as AggregationName).filter(
         esb
           .rangeQuery()
           .field(EsDonorDocumentField.alignmentsFailed)
           .gte(1),
       ),
-      filterAggregation('donorsWithNoAlignment' as AggregationName).filter(
+      filterAggregation('noAlignment' as AggregationName).filter(
         esb
           .boolQuery().must([
             esb
@@ -223,25 +223,25 @@ const programDonorSummaryStatsResolver: (
             .lte(0)
           ])
       ),
-      filterAggregation('donorsWithCompletedSanger' as AggregationName).filter(
+      filterAggregation('completedSanger' as AggregationName).filter(
         esb
           .rangeQuery()
           .field(EsDonorDocumentField.sangerVcsCompleted)
           .gte(1),
       ),
-      filterAggregation('donorsWithInProgressSanger' as AggregationName).filter(
+      filterAggregation('inProgressSanger' as AggregationName).filter(
         esb
           .rangeQuery()
           .field(EsDonorDocumentField.sangerVcsRunning)
           .gte(1),
       ),
-      filterAggregation('donorsWithFailedSanger' as AggregationName).filter(
+      filterAggregation('failedSanger' as AggregationName).filter(
         esb
           .rangeQuery()
           .field(EsDonorDocumentField.sangerVcsFailed)
           .gte(1),
       ),
-      filterAggregation('donorsWithNoSanger' as AggregationName).filter(
+      filterAggregation('noSanger' as AggregationName).filter(
         esb
           .boolQuery().must([
             esb
@@ -258,25 +258,25 @@ const programDonorSummaryStatsResolver: (
             .lte(0)
           ])
       ),
-      filterAggregation('donorsWithCompletedMutect' as AggregationName).filter(
+      filterAggregation('completedMutect' as AggregationName).filter(
         esb
           .rangeQuery()
           .field(EsDonorDocumentField.mutectCompleted)
           .gte(1),
       ),
-      filterAggregation('donorsWithInProgressMutect' as AggregationName).filter(
+      filterAggregation('inProgressMutect' as AggregationName).filter(
         esb
           .rangeQuery()
           .field(EsDonorDocumentField.mutectRunning)
           .gte(1),
       ),
-      filterAggregation('donorsWithFailedMutect' as AggregationName).filter(
+      filterAggregation('failedMutect' as AggregationName).filter(
         esb
           .rangeQuery()
           .field(EsDonorDocumentField.mutectFailed)
           .gte(1),
       ),
-      filterAggregation('donorsWithNoMutect' as AggregationName).filter(
+      filterAggregation('noMutect' as AggregationName).filter(
         esb
           .boolQuery().must([
             esb
@@ -319,30 +319,30 @@ const programDonorSummaryStatsResolver: (
       donorsWithAllCoreClinicalData: FilterAggregationResult;
       donorsInvalidWithCurrentDictionary: FilterAggregationResult;
 
-      donorsWithCompleteCoreCompletion: FilterAggregationResult;
-      donorsWithIncompleteCoreCompletion: FilterAggregationResult;
-      donorsWithNoCoreCompletion: FilterAggregationResult;
+      completeCoreCompletion: FilterAggregationResult;
+      incompleteCoreCompletion: FilterAggregationResult;
+      noCoreCompletion: FilterAggregationResult;
 
-      donorsWithValidSamplePairs: FilterAggregationResult;
-      donorsWithInvalidSamplePairs: FilterAggregationResult;
+      validSamplePairs: FilterAggregationResult;
+      invalidSamplePairs: FilterAggregationResult;
 
-      donorsWithValidRawReads: FilterAggregationResult;
-      donorsWithInvalidRawReads: FilterAggregationResult;
+      validRawReads: FilterAggregationResult;
+      invalidRawReads: FilterAggregationResult;
 
-      donorsWithCompletedAlignment: FilterAggregationResult;
-      donorsWithInProgressAlignment: FilterAggregationResult;
-      donorsWithFailedAlignment: FilterAggregationResult;
-      donorsWithNoAlignment: FilterAggregationResult;
+      completedAlignment: FilterAggregationResult;
+      inProgressAlignment: FilterAggregationResult;
+      failedAlignment: FilterAggregationResult;
+      noAlignment: FilterAggregationResult;
 
-      donorsWithCompletedSanger: FilterAggregationResult;
-      donorsWithInProgressSanger: FilterAggregationResult;
-      donorsWithFailedSanger: FilterAggregationResult;
-      donorsWithNoSanger: FilterAggregationResult;
+      completedSanger: FilterAggregationResult;
+      inProgressSanger: FilterAggregationResult;
+      failedSanger: FilterAggregationResult;
+      noSanger: FilterAggregationResult;
 
-      donorsWithCompletedMutect: FilterAggregationResult;
-      donorsWithInProgressMutect: FilterAggregationResult;
-      donorsWithFailedMutect: FilterAggregationResult;
-      donorsWithNoMutect: FilterAggregationResult;
+      completedMutect: FilterAggregationResult;
+      inProgressMutect: FilterAggregationResult;
+      failedMutect: FilterAggregationResult;
+      noMutect: FilterAggregationResult;
 
       allFilesCount: NumericAggregationResult;
       filesToQcCount: NumericAggregationResult;
@@ -370,30 +370,30 @@ const programDonorSummaryStatsResolver: (
           donorsWithAllCoreClinicalData: { doc_count: 0 },
           donorsInvalidWithCurrentDictionary: { doc_count: 0 },
 
-          donorsWithCompleteCoreCompletion: { doc_count: 0 },
-          donorsWithIncompleteCoreCompletion: { doc_count: 0 },
-          donorsWithNoCoreCompletion: { doc_count: 0 },
+          completeCoreCompletion: { doc_count: 0 },
+          incompleteCoreCompletion: { doc_count: 0 },
+          noCoreCompletion: { doc_count: 0 },
 
-          donorsWithValidSamplePairs: { doc_count: 0 },
-          donorsWithInvalidSamplePairs: { doc_count: 0 },
+          validSamplePairs: { doc_count: 0 },
+          invalidSamplePairs: { doc_count: 0 },
 
-          donorsWithValidRawReads: { doc_count: 0 },
-          donorsWithInvalidRawReads: { doc_count: 0 },
+          validRawReads: { doc_count: 0 },
+          invalidRawReads: { doc_count: 0 },
 
-          donorsWithCompletedAlignment: { doc_count: 0 },
-          donorsWithInProgressAlignment: { doc_count: 0 },
-          donorsWithFailedAlignment: { doc_count: 0 },
-          donorsWithNoAlignment: { doc_count: 0 },
+          completedAlignment: { doc_count: 0 },
+          inProgressAlignment: { doc_count: 0 },
+          failedAlignment: { doc_count: 0 },
+          noAlignment: { doc_count: 0 },
 
-          donorsWithCompletedSanger: { doc_count: 0 },
-          donorsWithInProgressSanger: { doc_count: 0 },
-          donorsWithFailedSanger: { doc_count: 0 },
-          donorsWithNoSanger: { doc_count: 0 },
+          completedSanger: { doc_count: 0 },
+          inProgressSanger: { doc_count: 0 },
+          failedSanger: { doc_count: 0 },
+          noSanger: { doc_count: 0 },
 
-          donorsWithCompletedMutect: { doc_count: 0 },
-          donorsWithInProgressMutect: { doc_count: 0 },
-          donorsWithFailedMutect: { doc_count: 0 },
-          donorsWithNoMutect: { doc_count: 0 },
+          completedMutect: { doc_count: 0 },
+          inProgressMutect: { doc_count: 0 },
+          failedMutect: { doc_count: 0 },
+          noMutect: { doc_count: 0 },
 
           allFilesCount: { value: 0 },
           filesToQcCount: { value: 0 },
@@ -428,32 +428,44 @@ const programDonorSummaryStatsResolver: (
     donorsInvalidWithCurrentDictionaryCount:
       aggregations.donorsInvalidWithCurrentDictionary.doc_count,
 
-      donorsWithCompleteCoreCompletion: aggregations.donorsWithCompleteCoreCompletion.doc_count,
-      donorsWithIncompleteCoreCompletion: aggregations.donorsWithIncompleteCoreCompletion.doc_count,
-      donorsWithNoCoreCompletion: aggregations.donorsWithNoCoreCompletion.doc_count,
+      coreCompletion: {
+        completed: aggregations.completeCoreCompletion.doc_count,
+        incomplete: aggregations.incompleteCoreCompletion.doc_count,
+        noData: aggregations.noCoreCompletion.doc_count,
+      },
 
-      donorsWithValidSamplePairs: aggregations.donorsWithValidSamplePairs.doc_count,
-      donorsWithInvalidSamplePairs: aggregations.donorsWithInvalidSamplePairs.doc_count,
+      sampleStatus: {
+        valid: aggregations.validSamplePairs.doc_count,
+        invalid: aggregations.invalidSamplePairs.doc_count,
+      },
 
-      donorsWithValidRawReads: aggregations.donorsWithValidRawReads.doc_count,
-      donorsWithInvalidRawReads: aggregations.donorsWithInvalidRawReads.doc_count,
+      rawReadsStatus: {
+        valid: aggregations.validRawReads.doc_count,
+        invalid: aggregations.invalidRawReads.doc_count,
+      },
 
-      donorsWithCompletedAlignment: aggregations.donorsWithCompletedAlignment.doc_count,
-      donorsWithInProgressAlignment: aggregations.donorsWithInProgressAlignment.doc_count,
-      donorsWithFailedAlignment: aggregations.donorsWithFailedAlignment.doc_count,
-      donorsWithNoAlignment: aggregations.donorsWithNoAlignment.doc_count,
+      alignmentStatusCount: {
+        completed: aggregations.completedAlignment.doc_count,
+        inProgress: aggregations.inProgressAlignment.doc_count,
+        failed: aggregations.failedAlignment.doc_count,
+        noData: aggregations.noAlignment.doc_count,
+      },
 
-      donorsWithCompletedSanger: aggregations.donorsWithCompletedSanger.doc_count,
-      donorsWithInProgressSanger: aggregations.donorsWithInProgressSanger.doc_count,
-      donorsWithFailedSanger: aggregations.donorsWithFailedSanger.doc_count,
-      donorsWithNoSanger: aggregations.donorsWithNoSanger.doc_count,
+      sangerStatusCount: {
+        completed: aggregations.completedSanger.doc_count,
+        inProgress: aggregations.inProgressSanger.doc_count,
+        failed: aggregations.failedSanger.doc_count,
+        noData: aggregations.noSanger.doc_count,
+      },
 
-      donorsWithCompletedMutect: aggregations.donorsWithCompletedMutect.doc_count,
-      donorsWithInProgressMutect: aggregations.donorsWithInProgressMutect.doc_count,
-      donorsWithFailedMutect: aggregations.donorsWithFailedMutect.doc_count,
-      donorsWithNoMutect: aggregations.donorsWithNoMutect.doc_count,
+      mutectStatusCount: {
+        completed: aggregations.completedMutect.doc_count,
+        inProgress: aggregations.inProgressMutect.doc_count,
+        failed: aggregations.failedMutect.doc_count,
+        noData: aggregations.noMutect.doc_count,
+      },
 
-    lastUpdate: aggregations.lastUpdate?.value ? new Date(aggregations.lastUpdate.value) : undefined,
+      lastUpdate: aggregations.lastUpdate?.value ? new Date(aggregations.lastUpdate.value) : undefined,
   };
 };
 

--- a/src/schemas/ProgramDonorSummary/resolvers/SummaryStats.ts
+++ b/src/schemas/ProgramDonorSummary/resolvers/SummaryStats.ts
@@ -54,7 +54,6 @@ const programDonorSummaryStatsResolver: (
 
   type AggregationName =
     | keyof ProgramDonorSummaryStats
-    | 'donorsWithAllCoreClinicalData'
     | 'donorsInvalidWithCurrentDictionary';
 
   const filterAggregation = (name: AggregationName, filterQuery?: esb.Query | undefined) =>
@@ -108,12 +107,6 @@ const programDonorSummaryStatsResolver: (
             .field(EsDonorDocumentField.publishedTumourAnalysis)
             .gt(0),
         ]),
-      ),
-      filterAggregation('donorsWithAllCoreClinicalData' as AggregationName).filter(
-        esb
-          .rangeQuery()
-          .field(EsDonorDocumentField.submittedCoreDataPercent)
-          .gte(1),
       ),
       filterAggregation('donorsInvalidWithCurrentDictionary' as AggregationName).filter(
         esb
@@ -316,7 +309,6 @@ const programDonorSummaryStatsResolver: (
       donorsProcessingMolecularDataCount: FilterAggregationResult;
       donorsWithReleasedFilesCount: FilterAggregationResult;
       donorsWithPublishedNormalAndTumourSamples: FilterAggregationResult;
-      donorsWithAllCoreClinicalData: FilterAggregationResult;
       donorsInvalidWithCurrentDictionary: FilterAggregationResult;
 
       completeCoreCompletion: FilterAggregationResult;
@@ -367,7 +359,6 @@ const programDonorSummaryStatsResolver: (
           donorsProcessingMolecularDataCount: { doc_count: 0 },
           donorsWithReleasedFilesCount: { doc_count: 0 },
           donorsWithPublishedNormalAndTumourSamples: { doc_count: 0 },
-          donorsWithAllCoreClinicalData: { doc_count: 0 },
           donorsInvalidWithCurrentDictionary: { doc_count: 0 },
 
           completeCoreCompletion: { doc_count: 0 },
@@ -421,7 +412,7 @@ const programDonorSummaryStatsResolver: (
       ? aggregations.donorsWithPublishedNormalAndTumourSamples.doc_count / hits.total.value
       : 0,
     percentageCoreClinical: hits.total.value
-      ? aggregations.donorsWithAllCoreClinicalData.doc_count / hits.total.value
+      ? aggregations.completeCoreCompletion.doc_count / hits.total.value
       : 0,
     allFilesCount: aggregations.allFilesCount.value,
     filesToQcCount: aggregations.filesToQcCount.value,

--- a/src/schemas/ProgramDonorSummary/resolvers/summaryEntriesAndStats.ts
+++ b/src/schemas/ProgramDonorSummary/resolvers/summaryEntriesAndStats.ts
@@ -306,26 +306,26 @@ const programDonorSummaryEntriesAndStatsResolver: (
           .field(EsDonorDocumentField.validWithCurrentDictionary)
           .value(false),
       ),
-      filterAggregation('donorsWithCompleteCoreCompletion' as AggregationName).filter(
+      filterAggregation('completeCoreCompletion' as AggregationName).filter(
         esb
           .termQuery()
           .field(EsDonorDocumentField.submittedCoreDataPercent)
           .value(1),
       ),
-      filterAggregation('donorsWithIncompleteCoreCompletion' as AggregationName).filter(
+      filterAggregation('incompleteCoreCompletion' as AggregationName).filter(
         esb
         .rangeQuery()
         .field(EsDonorDocumentField.submittedCoreDataPercent)
         .gt(0)
         .lt(1),
       ),
-      filterAggregation('donorsWithNoCoreCompletion' as AggregationName).filter(
+      filterAggregation('noCoreCompletion' as AggregationName).filter(
         esb
           .termQuery()
           .field(EsDonorDocumentField.submittedCoreDataPercent)
           .value(0),
       ),
-      filterAggregation('donorsWithValidSamplePairs' as AggregationName).filter(
+      filterAggregation('validSamplePairs' as AggregationName).filter(
         esb.boolQuery().must([
           esb
             .rangeQuery()
@@ -337,7 +337,7 @@ const programDonorSummaryEntriesAndStatsResolver: (
             .gt(0),
         ]),
       ),
-      filterAggregation('donorsWithInvalidSamplePairs' as AggregationName).filter(
+      filterAggregation('invalidSamplePairs' as AggregationName).filter(
         esb.boolQuery().should([
           esb
             .rangeQuery()
@@ -349,7 +349,7 @@ const programDonorSummaryEntriesAndStatsResolver: (
             .lte(0),
         ]),
       ),
-      filterAggregation('donorsWithValidRawReads' as AggregationName).filter(
+      filterAggregation('validRawReads' as AggregationName).filter(
         esb.boolQuery().must([
           esb
             .rangeQuery()
@@ -361,7 +361,7 @@ const programDonorSummaryEntriesAndStatsResolver: (
             .gte(1),
         ]),
       ),
-      filterAggregation('donorsWithInvalidRawReads' as AggregationName).filter(
+      filterAggregation('invalidRawReads' as AggregationName).filter(
         esb.boolQuery().should([
           esb
             .rangeQuery()
@@ -373,25 +373,25 @@ const programDonorSummaryEntriesAndStatsResolver: (
             .lte(0),
         ]),
       ),
-      filterAggregation('donorsWithCompletedAlignment' as AggregationName).filter(
+      filterAggregation('completedAlignment' as AggregationName).filter(
         esb
           .rangeQuery()
           .field(EsDonorDocumentField.alignmentsCompleted)
           .gte(1),
       ),
-      filterAggregation('donorsWithInProgressAlignment' as AggregationName).filter(
+      filterAggregation('inProgressAlignment' as AggregationName).filter(
         esb
           .rangeQuery()
           .field(EsDonorDocumentField.alignmentsRunning)
           .gte(1),
       ),
-      filterAggregation('donorsWithFailedAlignment' as AggregationName).filter(
+      filterAggregation('failedAlignment' as AggregationName).filter(
         esb
           .rangeQuery()
           .field(EsDonorDocumentField.alignmentsFailed)
           .gte(1),
       ),
-      filterAggregation('donorsWithNoAlignment' as AggregationName).filter(
+      filterAggregation('noAlignment' as AggregationName).filter(
         esb
           .boolQuery().must([
             esb
@@ -408,25 +408,25 @@ const programDonorSummaryEntriesAndStatsResolver: (
             .lte(0)
           ])
       ),
-      filterAggregation('donorsWithCompletedSanger' as AggregationName).filter(
+      filterAggregation('completedSanger' as AggregationName).filter(
         esb
           .rangeQuery()
           .field(EsDonorDocumentField.sangerVcsCompleted)
           .gte(1),
       ),
-      filterAggregation('donorsWithInProgressSanger' as AggregationName).filter(
+      filterAggregation('inProgressSanger' as AggregationName).filter(
         esb
           .rangeQuery()
           .field(EsDonorDocumentField.sangerVcsRunning)
           .gte(1),
       ),
-      filterAggregation('donorsWithFailedSanger' as AggregationName).filter(
+      filterAggregation('failedSanger' as AggregationName).filter(
         esb
           .rangeQuery()
           .field(EsDonorDocumentField.sangerVcsFailed)
           .gte(1),
       ),
-      filterAggregation('donorsWithNoSanger' as AggregationName).filter(
+      filterAggregation('noSanger' as AggregationName).filter(
         esb
           .boolQuery().must([
             esb
@@ -443,25 +443,25 @@ const programDonorSummaryEntriesAndStatsResolver: (
             .lte(0)
           ])
       ),
-      filterAggregation('donorsWithCompletedMutect' as AggregationName).filter(
+      filterAggregation('completedMutect' as AggregationName).filter(
         esb
           .rangeQuery()
           .field(EsDonorDocumentField.mutectCompleted)
           .gte(1),
       ),
-      filterAggregation('donorsWithInProgressMutect' as AggregationName).filter(
+      filterAggregation('inProgressMutect' as AggregationName).filter(
         esb
           .rangeQuery()
           .field(EsDonorDocumentField.mutectRunning)
           .gte(1),
       ),
-      filterAggregation('donorsWithFailedMutect' as AggregationName).filter(
+      filterAggregation('failedMutect' as AggregationName).filter(
         esb
           .rangeQuery()
           .field(EsDonorDocumentField.mutectFailed)
           .gte(1),
       ),
-      filterAggregation('donorsWithNoMutect' as AggregationName).filter(
+      filterAggregation('noMutect' as AggregationName).filter(
         esb
           .boolQuery().must([
             esb
@@ -513,30 +513,30 @@ const programDonorSummaryEntriesAndStatsResolver: (
       donorsWithAllCoreClinicalData: FilterAggregationResult;
       donorsInvalidWithCurrentDictionary: FilterAggregationResult;
 
-      donorsWithCompleteCoreCompletion: FilterAggregationResult;
-      donorsWithIncompleteCoreCompletion: FilterAggregationResult;
-      donorsWithNoCoreCompletion: FilterAggregationResult;
+      completeCoreCompletion: FilterAggregationResult;
+      incompleteCoreCompletion: FilterAggregationResult;
+      noCoreCompletion: FilterAggregationResult;
 
-      donorsWithValidSamplePairs: FilterAggregationResult;
-      donorsWithInvalidSamplePairs: FilterAggregationResult;
+      validSamplePairs: FilterAggregationResult;
+      invalidSamplePairs: FilterAggregationResult;
 
-      donorsWithValidRawReads: FilterAggregationResult;
-      donorsWithInvalidRawReads: FilterAggregationResult;
+      validRawReads: FilterAggregationResult;
+      invalidRawReads: FilterAggregationResult;
 
-      donorsWithCompletedAlignment: FilterAggregationResult;
-      donorsWithInProgressAlignment: FilterAggregationResult;
-      donorsWithFailedAlignment: FilterAggregationResult;
-      donorsWithNoAlignment: FilterAggregationResult;
+      completedAlignment: FilterAggregationResult;
+      inProgressAlignment: FilterAggregationResult;
+      failedAlignment: FilterAggregationResult;
+      noAlignment: FilterAggregationResult;
 
-      donorsWithCompletedSanger: FilterAggregationResult;
-      donorsWithInProgressSanger: FilterAggregationResult;
-      donorsWithFailedSanger: FilterAggregationResult;
-      donorsWithNoSanger: FilterAggregationResult;
+      completedSanger: FilterAggregationResult;
+      inProgressSanger: FilterAggregationResult;
+      failedSanger: FilterAggregationResult;
+      noSanger: FilterAggregationResult;
 
-      donorsWithCompletedMutect: FilterAggregationResult;
-      donorsWithInProgressMutect: FilterAggregationResult;
-      donorsWithFailedMutect: FilterAggregationResult;
-      donorsWithNoMutect: FilterAggregationResult;
+      completedMutect: FilterAggregationResult;
+      inProgressMutect: FilterAggregationResult;
+      failedMutect: FilterAggregationResult;
+      noMutect: FilterAggregationResult;
 
       allFilesCount: NumericAggregationResult;
       filesToQcCount: NumericAggregationResult;
@@ -625,30 +625,42 @@ const programDonorSummaryEntriesAndStatsResolver: (
       donorsInvalidWithCurrentDictionaryCount:
       result.aggregations.donorsInvalidWithCurrentDictionary.doc_count,
 
-      donorsWithCompleteCoreCompletion: result.aggregations.donorsWithCompleteCoreCompletion.doc_count,
-      donorsWithIncompleteCoreCompletion: result.aggregations.donorsWithIncompleteCoreCompletion.doc_count,
-      donorsWithNoCoreCompletion: result.aggregations.donorsWithNoCoreCompletion.doc_count,
+      coreCompletion: {
+        completed: result.aggregations.completeCoreCompletion.doc_count,
+        incomplete: result.aggregations.incompleteCoreCompletion.doc_count,
+        noData: result.aggregations.noCoreCompletion.doc_count,
+      },
 
-      donorsWithValidSamplePairs: result.aggregations.donorsWithValidSamplePairs.doc_count,
-      donorsWithInvalidSamplePairs: result.aggregations.donorsWithInvalidSamplePairs.doc_count,
+      sampleStatus: {
+        valid: result.aggregations.validSamplePairs.doc_count,
+        invalid: result.aggregations.invalidSamplePairs.doc_count,
+      },
 
-      donorsWithValidRawReads: result.aggregations.donorsWithValidRawReads.doc_count,
-      donorsWithInvalidRawReads: result.aggregations.donorsWithInvalidRawReads.doc_count,
+      rawReadsStatus: {
+        valid: result.aggregations.validRawReads.doc_count,
+        invalid: result.aggregations.invalidRawReads.doc_count,
+      },
 
-      donorsWithCompletedAlignment: result.aggregations.donorsWithCompletedAlignment.doc_count,
-      donorsWithInProgressAlignment: result.aggregations.donorsWithInProgressAlignment.doc_count,
-      donorsWithFailedAlignment: result.aggregations.donorsWithFailedAlignment.doc_count,
-      donorsWithNoAlignment: result.aggregations.donorsWithNoAlignment.doc_count,
+      alignmentStatusCount: {
+        completed: result.aggregations.completedAlignment.doc_count,
+        inProgress: result.aggregations.inProgressAlignment.doc_count,
+        failed: result.aggregations.failedAlignment.doc_count,
+        noData: result.aggregations.noAlignment.doc_count,
+      },
 
-      donorsWithCompletedSanger: result.aggregations.donorsWithCompletedSanger.doc_count,
-      donorsWithInProgressSanger: result.aggregations.donorsWithInProgressSanger.doc_count,
-      donorsWithFailedSanger: result.aggregations.donorsWithFailedSanger.doc_count,
-      donorsWithNoSanger: result.aggregations.donorsWithNoSanger.doc_count,
+      sangerStatusCount: {
+        completed: result.aggregations.completedSanger.doc_count,
+        inProgress: result.aggregations.inProgressSanger.doc_count,
+        failed: result.aggregations.failedSanger.doc_count,
+        noData: result.aggregations.noSanger.doc_count,
+      },
 
-      donorsWithCompletedMutect: result.aggregations.donorsWithCompletedMutect.doc_count,
-      donorsWithInProgressMutect: result.aggregations.donorsWithInProgressMutect.doc_count,
-      donorsWithFailedMutect: result.aggregations.donorsWithFailedMutect.doc_count,
-      donorsWithNoMutect: result.aggregations.donorsWithNoMutect.doc_count,
+      mutectStatusCount: {
+        completed: result.aggregations.completedMutect.doc_count,
+        inProgress: result.aggregations.inProgressMutect.doc_count,
+        failed: result.aggregations.failedMutect.doc_count,
+        noData: result.aggregations.noMutect.doc_count,
+      },
 
       lastUpdate: result.aggregations.lastUpdate?.value ? new Date(result.aggregations.lastUpdate.value) : undefined,
     }

--- a/src/schemas/ProgramDonorSummary/resolvers/summaryEntriesAndStats.ts
+++ b/src/schemas/ProgramDonorSummary/resolvers/summaryEntriesAndStats.ts
@@ -236,7 +236,6 @@ const programDonorSummaryEntriesAndStatsResolver: (
 
   type AggregationName =
   | keyof ProgramDonorSummaryStats
-  | 'donorsWithAllCoreClinicalData'
   | 'donorsInvalidWithCurrentDictionary';
 
   const filterAggregation = (name: AggregationName, filterQuery?: esb.Query | undefined) =>
@@ -293,12 +292,6 @@ const programDonorSummaryEntriesAndStatsResolver: (
             .field(EsDonorDocumentField.publishedNormalAnalysis)
             .gt(0),
         ]),
-      ),
-      filterAggregation('donorsWithAllCoreClinicalData' as AggregationName).filter(
-        esb
-          .rangeQuery()
-          .field(EsDonorDocumentField.submittedCoreDataPercent)
-          .gte(1),
       ),
       filterAggregation('donorsInvalidWithCurrentDictionary' as AggregationName).filter(
         esb
@@ -510,7 +503,6 @@ const programDonorSummaryEntriesAndStatsResolver: (
       donorsProcessingMolecularDataCount: FilterAggregationResult;
       donorsWithReleasedFilesCount: FilterAggregationResult;
       donorsWithPublishedNormalAndTumourSamples: FilterAggregationResult;
-      donorsWithAllCoreClinicalData: FilterAggregationResult;
       donorsInvalidWithCurrentDictionary: FilterAggregationResult;
 
       completeCoreCompletion: FilterAggregationResult;
@@ -567,8 +559,33 @@ const programDonorSummaryEntriesAndStatsResolver: (
           donorsProcessingMolecularDataCount: { doc_count: 0 },
           donorsWithReleasedFilesCount: { doc_count: 0 },
           donorsWithPublishedNormalAndTumourSamples: { doc_count: 0 },
-          donorsWithAllCoreClinicalData: { doc_count: 0 },
           donorsInvalidWithCurrentDictionary: { doc_count: 0 },
+
+          completeCoreCompletion: { doc_count: 0 },
+          incompleteCoreCompletion: { doc_count: 0 },
+          noCoreCompletion: { doc_count: 0 },
+
+          validSamplePairs: { doc_count: 0 },
+          invalidSamplePairs: { doc_count: 0 },
+
+          validRawReads: { doc_count: 0 },
+          invalidRawReads: { doc_count: 0 },
+
+          completedAlignment: { doc_count: 0 },
+          inProgressAlignment: { doc_count: 0 },
+          failedAlignment: { doc_count: 0 },
+          noAlignment: { doc_count: 0 },
+
+          completedSanger: { doc_count: 0 },
+          inProgressSanger: { doc_count: 0 },
+          failedSanger: { doc_count: 0 },
+          noSanger: { doc_count: 0 },
+
+          completedMutect: { doc_count: 0 },
+          inProgressMutect: { doc_count: 0 },
+          failedMutect: { doc_count: 0 },
+          noMutect: { doc_count: 0 },
+
           allFilesCount: { value: 0 },
           filesToQcCount: { value: 0 },
         }
@@ -618,7 +635,7 @@ const programDonorSummaryEntriesAndStatsResolver: (
         ? result.aggregations.donorsWithPublishedNormalAndTumourSamples.doc_count / result.hits.total.value
         : 0,
       percentageCoreClinical: result.hits.total.value
-        ? result.aggregations.donorsWithAllCoreClinicalData.doc_count / result.hits.total.value
+        ? result.aggregations.completeCoreCompletion.doc_count / result.hits.total.value
         : 0,
       allFilesCount: result.aggregations.allFilesCount.value,
       filesToQcCount: result.aggregations.filesToQcCount.value,

--- a/src/schemas/ProgramDonorSummary/resolvers/types.ts
+++ b/src/schemas/ProgramDonorSummary/resolvers/types.ts
@@ -91,33 +91,39 @@ export type ProgramDonorSummaryStats = {
   partiallyReleasedDonorsCount: number;
   noReleaseDonorsCount: number;
   donorsInvalidWithCurrentDictionaryCount: number;
-  donorsWithCompleteCoreCompletion: number;
-  donorsWithIncompleteCoreCompletion: number;
-  donorsWithNoCoreCompletion: number;
 
-  donorsWithValidSamplePairs: number;
-  donorsWithInvalidSamplePairs: number;
+  coreCompletion: CoreCompletionStatusCount;
 
-  donorsWithValidRawReads: number;
-  donorsWithInvalidRawReads: number;
+  sampleStatus: SamplePairsStatusCount;
 
-  donorsWithCompletedAlignment: number;
-  donorsWithInProgressAlignment: number;
-  donorsWithFailedAlignment: number;
-  donorsWithNoAlignment: number;
+  rawReadsStatus: SamplePairsStatusCount;
 
-  donorsWithCompletedSanger: number;
-  donorsWithInProgressSanger: number;
-  donorsWithFailedSanger: number;
-  donorsWithNoSanger: number;
+  alignmentStatusCount: WorkflowStatusCount;
 
-  donorsWithCompletedMutect: number;
-  donorsWithInProgressMutect: number;
-  donorsWithFailedMutect: number;
-  donorsWithNoMutect: number;
+  sangerStatusCount: WorkflowStatusCount;
+
+  mutectStatusCount: WorkflowStatusCount;
 
   lastUpdate?: Date;
 };
+
+type CoreCompletionStatusCount = {
+  completed: number;
+  incomplete: number;
+  noData: number;
+}
+
+type SamplePairsStatusCount = {
+  valid: number;
+  invalid: number;
+}
+
+type WorkflowStatusCount = {
+  noData: number;
+  completed: number;
+  inProgress: number;
+  failed: number;
+}
 
 export type ProgramDonorSummaryStatsGqlResponse = ProgramDonorSummaryStats & {
   id: string;

--- a/src/schemas/ProgramDonorSummary/resolvers/types.ts
+++ b/src/schemas/ProgramDonorSummary/resolvers/types.ts
@@ -91,6 +91,31 @@ export type ProgramDonorSummaryStats = {
   partiallyReleasedDonorsCount: number;
   noReleaseDonorsCount: number;
   donorsInvalidWithCurrentDictionaryCount: number;
+  donorsWithCompleteCoreCompletion: number;
+  donorsWithIncompleteCoreCompletion: number;
+  donorsWithNoCoreCompletion: number;
+
+  donorsWithValidSamplePairs: number;
+  donorsWithInvalidSamplePairs: number;
+
+  donorsWithValidRawReads: number;
+  donorsWithInvalidRawReads: number;
+
+  donorsWithCompletedAlignment: number;
+  donorsWithInProgressAlignment: number;
+  donorsWithFailedAlignment: number;
+  donorsWithNoAlignment: number;
+
+  donorsWithCompletedSanger: number;
+  donorsWithInProgressSanger: number;
+  donorsWithFailedSanger: number;
+  donorsWithNoSanger: number;
+
+  donorsWithCompletedMutect: number;
+  donorsWithInProgressMutect: number;
+  donorsWithFailedMutect: number;
+  donorsWithNoMutect: number;
+
   lastUpdate?: Date;
 };
 


### PR DESCRIPTION
**Description of changes**

<!-- Please add a brief description of the changes here. -->

Feature to add aggregation fields  to `programDonorSummary` and `programDonorSummaryStats` API, new fields added are:
```
      coreCompletion {
        completed
        incomplete
        noData
      }      
      
      sampleStatus {
        valid
        invalid
      }
      
      rawReadsStatus {
        valid
        invalid
      }      
      
      alignmentStatusCount{
        completed
        inProgress
        failed
        noData
      }
      
      sangerStatusCount{
        completed
        inProgress
        failed
        noData
      }
      mutectStatusCount{
        completed
        inProgress
        failed
        noData
      }
```

**Type of Change**

- [ ] Bug
- [x] New Feature