### PR TITLE
Add index files to score downloads

### DIFF
--- a/src/routes/file-storage-api/handlers/entitiesHandler.ts
+++ b/src/routes/file-storage-api/handlers/entitiesHandler.ts
@@ -149,7 +149,7 @@ const createEntitiesHandler = ({ esClient }: { esClient: Client }): Handler => {
           .boolQuery()
           // TODO: All of the `as string` casting in this section was added to silence the typescript compiler, it needs to be tested
           // the solution is likely in the types being applied to the Request object, such that it doesnt know if the query params are string or parsed into arrays
-          .should([
+          .must([
             parsedRequestQuery.id
               ? esb.termsQuery(FILE_METADATA_FIELDS['object_id'], parsedRequestQuery.id as string)
               : emptyFilter(),

--- a/src/routes/file-storage-api/handlers/entitiesHandler.ts
+++ b/src/routes/file-storage-api/handlers/entitiesHandler.ts
@@ -153,12 +153,6 @@ const createEntitiesHandler = ({ esClient }: { esClient: Client }): Handler => {
             parsedRequestQuery.id
               ? esb.termsQuery(FILE_METADATA_FIELDS['object_id'], parsedRequestQuery.id as string)
               : emptyFilter(),
-            parsedRequestQuery.id
-              ? esb.termsQuery(
-                  FILE_METADATA_FIELDS['file.index_file.id'],
-                  parsedRequestQuery.id as string,
-                )
-              : emptyFilter(),
             parsedRequestQuery.fileName
               ? esb.termsQuery(
                   FILE_METADATA_FIELDS['file.name'],

--- a/src/routes/file-storage-api/utils.ts
+++ b/src/routes/file-storage-api/utils.ts
@@ -11,11 +11,15 @@ export const getEsFileDocumentByObjectId = (esClient: Client) => (objectId: stri
   esClient
     .search({
       index: ARRANGER_FILE_CENTRIC_INDEX,
-      body: esb
-        .requestBodySearch()
-        .query(esb.boolQuery().must(esb.termQuery(FILE_METADATA_FIELDS['object_id'], objectId))),
+      body: esb.requestBodySearch().query(
+        esb.boolQuery().should([
+          // ID could be file ID or index_file ID
+          esb.termQuery(FILE_METADATA_FIELDS['object_id'], objectId),
+          esb.termsQuery(FILE_METADATA_FIELDS['file.index_file.object_id'], objectId),
+        ]),
+      ),
     })
-    .then(res => res.body.hits.hits[0]?._source as EsFileCentricDocument | undefined);
+    .then(res => res.body.hits.hits[0]._source as EsFileCentricDocument | undefined);
 
 export type SongEntity = {
   id: string;
@@ -32,3 +36,17 @@ export const toSongEntity = (file: EsFileCentricDocument): SongEntity => ({
   gnosId: file.analysis.analysis_id,
   projectCode: file.study_id,
 });
+
+export const getIndexFile = (file: EsFileCentricDocument): SongEntity | undefined => {
+  if (!file.file.index_file) {
+    return;
+  }
+  const output = {
+    access: file.file_access,
+    fileName: file.file.index_file.name,
+    id: file.file.index_file.object_id,
+    gnosId: file.analysis.analysis_id,
+    projectCode: file.study_id,
+  };
+  return output;
+};

--- a/src/routes/file-storage-api/utils.ts
+++ b/src/routes/file-storage-api/utils.ts
@@ -19,7 +19,7 @@ export const getEsFileDocumentByObjectId = (esClient: Client) => (objectId: stri
         ]),
       ),
     })
-    .then(res => res.body.hits.hits[0]._source as EsFileCentricDocument | undefined);
+    .then(res => res.body.hits.hits[0]?._source as EsFileCentricDocument | undefined);
 
 export type SongEntity = {
   id: string;

--- a/src/utils/commonTypes/EsFileCentricDocument.ts
+++ b/src/utils/commonTypes/EsFileCentricDocument.ts
@@ -151,7 +151,7 @@ export type EsFileCentricDocument = {
     size: number;
     md5sum: string;
     name: string;
-    index_file: {
+    index_file?: {
       object_id: string;
       file_type: string;
       md5sum: string;
@@ -334,6 +334,8 @@ export const FILE_METADATA_FIELDS = {
   'file.md5sum': 'file.md5sum' as 'file.md5sum',
   'file.name': 'file.name' as 'file.name',
   'file.index_file': 'file.index_file' as 'file.index_file',
+  'file.index_file.id': 'file.index_file.id' as 'file.index_file.id',
+  'file.index_file.object_id': 'file.index_file.object_id' as 'file.index_file.object_id',
   'file.object_id': 'file.object_id' as 'file.object_id',
   'file.file_type': 'file.file_type' as 'file.file_type',
   'file.file_type.md5sum': 'file.file_type.md5sum' as 'file.file_type.md5sum',


### PR DESCRIPTION
**Description of changes**
The Index Files associated with a file are included in the documents in the file_centric index. This PR takes advantage of this to include those files in the `/entries` requests from the score client. The end result is that a request for a file download will now also send the index file to the score client for download

**Type of Change**

- [ ] Bug
- [x] New Feature
