### PR TITLE
add option to exclude sample registration downloading

### DIFF
--- a/src/resources/swagger/index.yaml
+++ b/src/resources/swagger/index.yaml
@@ -87,7 +87,8 @@ paths:
           in: query
           description: Boolean value for whether to exclude downloading sample registration file. Accepted values are "true" or "false", default to false.
           required: false
-          type: boolean
+          schema:
+            type: boolean
       responses:
         "200":
           description: "A zip file with all schema templates"

--- a/src/resources/swagger/index.yaml
+++ b/src/resources/swagger/index.yaml
@@ -76,12 +76,18 @@ paths:
                 format: binary
         "500":
           description: Internal server error
-  "/clinical/template/all":
+  "/clinical/template/all/{excludeSampleRegistration}":
     get:
       tags:
         - Clinical Proxies
-      summary: Download a zip file with templates for all schema
+      summary: Download a zip file with templates for all schema, with the option to exclude sample registration.
       description: "- the file name of the zip file is not determined by this endpoint"
+      parameters:
+        - name: excludeSampleRegistration
+          in: path
+          description: boolean value for whether to exclude downloading sample registration file. Accepted values are "true" or "false".
+          required: true
+          type: string
       responses:
         "200":
           description: "A zip file with all schema templates"

--- a/src/resources/swagger/index.yaml
+++ b/src/resources/swagger/index.yaml
@@ -76,7 +76,7 @@ paths:
                 format: binary
         "500":
           description: Internal server error
-  "/clinical/template/all/{excludeSampleRegistration}":
+  "/clinical/template/all":
     get:
       tags:
         - Clinical Proxies
@@ -84,10 +84,10 @@ paths:
       description: "- the file name of the zip file is not determined by this endpoint"
       parameters:
         - name: excludeSampleRegistration
-          in: path
-          description: boolean value for whether to exclude downloading sample registration file. Accepted values are "true" or "false".
-          required: true
-          type: string
+          in: query
+          description: Boolean value for whether to exclude downloading sample registration file. Accepted values are "true" or "false", default to false.
+          required: false
+          type: boolean
       responses:
         "200":
           description: "A zip file with all schema templates"

--- a/src/routes/clinical-proxy.ts
+++ b/src/routes/clinical-proxy.ts
@@ -22,10 +22,9 @@ import { CLINICAL_SERVICE_ROOT } from '../config';
 import logger from '../utils/logger';
 import express from 'express';
 import { Request, Response } from 'express';
-const router = express.Router();
-
 import { createProxyMiddleware } from 'http-proxy-middleware';
 
+const router = express.Router();
 // Our specification download service can't use GraphQL because GraphQL specification requires the content-type
 // that it returns be json, and we want to be able to return other content types, such as tab-separated-values,
 // so that the user is automatically prompted to save the file from their browser.
@@ -35,6 +34,25 @@ const handleError = (err: Error, req: Request, res: Response) => {
   logger.error('Clinical Router Error - ' + err);
   return res.status(500).send('Internal Server Error');
 };
+
+router.use(
+  '/template/all/:excludeSampleRegistration',
+  createProxyMiddleware({
+    target: CLINICAL_SERVICE_ROOT,
+    pathRewrite: (pathName: string, req: Request) => {
+      const exclude = req.params.excludeSampleRegistration;
+      return urlJoin('/dictionary/template/all', `?excludeSampleRegistration=${exclude}`);
+    },
+    onError: handleError,
+    changeOrigin: true,
+    onProxyReq(proxyReq, req, res) {
+      const exclude = req.params.excludeSampleRegistration;
+      if (exclude !== 'true' && exclude !== 'false') {
+        res.status(400).send(`The accepted values of excludeSampleRegistration are 'true' or 'false'.`);
+      }
+    }
+  }),
+);
 
 router.use(
   '/template/:template',

--- a/src/routes/clinical-proxy.ts
+++ b/src/routes/clinical-proxy.ts
@@ -36,18 +36,19 @@ const handleError = (err: Error, req: Request, res: Response) => {
 };
 
 router.use(
-  '/template/all/:excludeSampleRegistration',
+  '/template/all',
   createProxyMiddleware({
     target: CLINICAL_SERVICE_ROOT,
     pathRewrite: (pathName: string, req: Request) => {
-      const exclude = req.params.excludeSampleRegistration;
+      const param = req.query.excludeSampleRegistration;
+      const exclude = param === undefined ? 'false' : param === 'true';
       return urlJoin('/dictionary/template/all', `?excludeSampleRegistration=${exclude}`);
     },
     onError: handleError,
     changeOrigin: true,
     onProxyReq(proxyReq, req, res) {
-      const exclude = req.params.excludeSampleRegistration;
-      if (exclude !== 'true' && exclude !== 'false') {
+      const exclude = req.query.excludeSampleRegistration;
+      if (exclude !== 'true' && exclude !== 'false' && exclude !== undefined) {
         res.status(400).send(`The accepted values of excludeSampleRegistration are 'true' or 'false'.`);
       }
     }

--- a/src/routes/clinical-proxy.ts
+++ b/src/routes/clinical-proxy.ts
@@ -40,15 +40,14 @@ router.use(
   createProxyMiddleware({
     target: CLINICAL_SERVICE_ROOT,
     pathRewrite: (pathName: string, req: Request) => {
-      const param = req.query.excludeSampleRegistration;
-      const exclude = param === undefined ? 'false' : param === 'true';
+      const exclude = req.query.excludeSampleRegistration === 'true';
       return urlJoin('/dictionary/template/all', `?excludeSampleRegistration=${exclude}`);
     },
     onError: handleError,
     changeOrigin: true,
     onProxyReq(proxyReq, req, res) {
       const exclude = req.query.excludeSampleRegistration;
-      if (exclude !== 'true' && exclude !== 'false' && exclude !== undefined) {
+      if (exclude && exclude !== 'true' && exclude !== 'false') {
         res.status(400).send(`The accepted values of excludeSampleRegistration are 'true' or 'false'.`);
       }
     }


### PR DESCRIPTION
**Description of changes**

Adds a new resolver for `/template/all/` endpoint to allow optional downloading for sample registration file.

<!-- Please add a brief description of the changes here. -->

**Type of Change**

- [ ] Bug
- [x] New Feature