### PR TITLE
Allow Open+Public files to be downloaded without auth

### DIFF
--- a/src/routes/file-storage-api/handlers/entitiesIdHandler.ts
+++ b/src/routes/file-storage-api/handlers/entitiesIdHandler.ts
@@ -26,14 +26,6 @@ import { getEsFileDocumentByObjectId, toSongEntity } from '../utils';
 
 const createEntitiesIdHandler = ({ esClient }: { esClient: Client }): Handler => {
   return async (req: AuthenticatedRequest, res, next) => {
-    if (!req.auth.authenticated) {
-      // token was invalid
-      res
-        .status(401)
-        .send('Invalid access token')
-        .end();
-      return;
-    }
     const file = await getEsFileDocumentByObjectId(esClient)(req.params.fileObjectId);
     if (!file) {
       res


### PR DESCRIPTION
**Description of changes**

Removed Authenticated check at start of entitiesId request handler and this allows completion through the whole process, all required auth rules still respected.

**Type of Change**

- [x] Bug
- [ ] New Feature
