### PR TITLE
👽️ Add Open Access Fields to Donor Summary Schema (#490)

### DIFF
--- a/compose/donors.json
+++ b/compose/donors.json
@@ -11,6 +11,9 @@
     "mutectCompleted": 2,
     "mutectRunning": 0,
     "mutectFailed": 0,
+    "openAccessCompleted": 2,
+    "openAccessRunning": 0,
+    "openAccessFailed": 0,
     "totalFilesCount": 0,
     "filesToQcCount": 0,
     "releaseStatus": "NO_RELEASE",
@@ -29,7 +32,8 @@
     "alignmentFirstPublishedDate": "2020-12-11T19:35:42.567Z",
     "mutectFirstPublishedDate": "2020-12-11T19:35:42.567Z",
     "rawReadsFirstPublishedDate": "2020-12-11T19:35:42.567Z",
-    "sangerVcsFirstPublishedDate": "2020-12-11T19:35:42.567Z"
+    "sangerVcsFirstPublishedDate": "2020-12-11T19:35:42.567Z",
+    "openAccessFirstPublishedDate": "2020-12-11T19:35:42.567Z"
   },
   {
     "publishedNormalAnalysis": 2,
@@ -43,6 +47,9 @@
     "mutectCompleted": 2,
     "mutectRunning": 0,
     "mutectFailed": 0,
+    "openAccessCompleted": 2,
+    "openAccessRunning": 0,
+    "openAccessFailed": 0,
     "totalFilesCount": 0,
     "filesToQcCount": 0,
     "releaseStatus": "NO_RELEASE",
@@ -60,7 +67,8 @@
     "createdAt": "2020-11-09T21:25:17.717Z","alignmentFirstPublishedDate": "2020-12-11T19:35:42.567Z",
     "mutectFirstPublishedDate": "2020-12-11T19:35:42.567Z",
     "rawReadsFirstPublishedDate": "2020-12-11T19:35:42.567Z",
-    "sangerVcsFirstPublishedDate": "2020-12-11T19:35:42.567Z"
+    "sangerVcsFirstPublishedDate": "2020-12-11T19:35:42.567Z",
+    "openAccessFirstPublishedDate": "2020-12-11T19:35:42.567Z"
   },
   {
     "publishedNormalAnalysis": 2,
@@ -74,6 +82,9 @@
     "mutectCompleted": 3,
     "mutectRunning": 0,
     "mutectFailed": 0,
+    "openAccessCompleted": 3,
+    "openAccessRunning": 0,
+    "openAccessFailed": 0,
     "totalFilesCount": 0,
     "filesToQcCount": 0,
     "releaseStatus": "NO_RELEASE",
@@ -92,7 +103,8 @@
     "alignmentFirstPublishedDate": "2020-12-11T19:35:42.567Z",
     "mutectFirstPublishedDate": "2020-12-11T19:35:42.567Z",
     "rawReadsFirstPublishedDate": "2020-12-11T19:35:42.567Z",
-    "sangerVcsFirstPublishedDate": "2020-12-11T19:35:42.567Z"
+    "sangerVcsFirstPublishedDate": "2020-12-11T19:35:42.567Z",
+    "openAccessFirstPublishedDate": "2020-12-11T19:35:42.567Z"
   },
   {
     "publishedNormalAnalysis": 2,
@@ -106,6 +118,9 @@
     "mutectCompleted": 2,
     "mutectRunning": 0,
     "mutectFailed": 0,
+    "openAccessCompleted": 2,
+    "openAccessRunning": 0,
+    "openAccessFailed": 0,
     "totalFilesCount": 0,
     "filesToQcCount": 0,
     "releaseStatus": "NO_RELEASE",
@@ -123,7 +138,8 @@
     "createdAt": "2020-11-09T21:25:17.717Z","alignmentFirstPublishedDate": "2020-12-11T19:35:42.567Z",
     "mutectFirstPublishedDate": "2020-12-11T19:35:42.567Z",
     "rawReadsFirstPublishedDate": "2020-12-11T19:35:42.567Z",
-    "sangerVcsFirstPublishedDate": "2020-12-11T19:35:42.567Z"
+    "sangerVcsFirstPublishedDate": "2020-12-11T19:35:42.567Z",
+    "openAccessFirstPublishedDate": "2020-12-11T19:35:42.567Z"
   },
   {
     "publishedNormalAnalysis": 2,
@@ -137,6 +153,9 @@
     "mutectCompleted": 2,
     "mutectRunning": 0,
     "mutectFailed": 0,
+    "openAccessCompleted": 2,
+    "openAccessRunning": 0,
+    "openAccessFailed": 0,
     "totalFilesCount": 0,
     "filesToQcCount": 0,
     "releaseStatus": "NO_RELEASE",
@@ -155,7 +174,8 @@
     "alignmentFirstPublishedDate": "2020-12-11T19:35:42.567Z",
     "mutectFirstPublishedDate": "2020-12-11T19:35:42.567Z",
     "rawReadsFirstPublishedDate": "2020-12-11T19:35:42.567Z",
-    "sangerVcsFirstPublishedDate": "2020-12-11T19:35:42.567Z"
+    "sangerVcsFirstPublishedDate": "2020-12-11T19:35:42.567Z",
+    "openAccessFirstPublishedDate": "2020-12-11T19:35:42.567Z"
   },
   {
     "publishedNormalAnalysis": 1,
@@ -169,6 +189,9 @@
     "mutectCompleted": 1,
     "mutectRunning": 0,
     "mutectFailed": 0,
+    "openAccessCompleted": 1,
+    "openAccessRunning": 0,
+    "openAccessFailed": 0,
     "totalFilesCount": 0,
     "filesToQcCount": 0,
     "releaseStatus": "NO_RELEASE",
@@ -187,7 +210,8 @@
     "alignmentFirstPublishedDate": "2020-12-11T19:35:42.567Z",
     "mutectFirstPublishedDate": "2020-12-11T19:35:42.567Z",
     "rawReadsFirstPublishedDate": "2020-12-11T19:35:42.567Z",
-    "sangerVcsFirstPublishedDate": "2020-12-11T19:35:42.567Z"
+    "sangerVcsFirstPublishedDate": "2020-12-11T19:35:42.567Z",
+    "openAccessFirstPublishedDate": "2020-12-11T19:35:42.567Z"
   },
   {
     "publishedNormalAnalysis": 2,
@@ -201,6 +225,9 @@
     "mutectCompleted": 2,
     "mutectRunning": 0,
     "mutectFailed": 0,
+    "openAccessCompleted": 2,
+    "openAccessRunning": 0,
+    "openAccessFailed": 0,
     "totalFilesCount": 0,
     "filesToQcCount": 0,
     "releaseStatus": "NO_RELEASE",
@@ -219,7 +246,8 @@
     "alignmentFirstPublishedDate": "2020-12-11T19:35:42.567Z",
     "mutectFirstPublishedDate": "2020-12-11T19:35:42.567Z",
     "rawReadsFirstPublishedDate": "2020-12-11T19:35:42.567Z",
-    "sangerVcsFirstPublishedDate": "2020-12-11T19:35:42.567Z"
+    "sangerVcsFirstPublishedDate": "2020-12-11T19:35:42.567Z",
+    "openAccessFirstPublishedDate": "2020-12-11T19:35:42.567Z"
   },
   {
     "publishedNormalAnalysis": 2,
@@ -233,6 +261,9 @@
     "mutectCompleted": 2,
     "mutectRunning": 0,
     "mutectFailed": 0,
+    "openAccessCompleted": 2,
+    "openAccessRunning": 0,
+    "openAccessFailed": 0,
     "totalFilesCount": 0,
     "filesToQcCount": 0,
     "releaseStatus": "NO_RELEASE",
@@ -251,7 +282,8 @@
     "alignmentFirstPublishedDate": "2020-12-11T19:35:42.567Z",
     "mutectFirstPublishedDate": "2020-12-11T19:35:42.567Z",
     "rawReadsFirstPublishedDate": "2020-12-11T19:35:42.567Z",
-    "sangerVcsFirstPublishedDate": "2020-12-11T19:35:42.567Z"
+    "sangerVcsFirstPublishedDate": "2020-12-11T19:35:42.567Z",
+    "openAccessFirstPublishedDate": "2020-12-11T19:35:42.567Z"
   },
   {
     "publishedNormalAnalysis": 1,
@@ -265,6 +297,9 @@
     "mutectCompleted": 1,
     "mutectRunning": 0,
     "mutectFailed": 0,
+    "openAccessCompleted": 1,
+    "openAccessRunning": 0,
+    "openAccessFailed": 0,
     "totalFilesCount": 0,
     "filesToQcCount": 0,
     "releaseStatus": "NO_RELEASE",
@@ -283,7 +318,8 @@
     "alignmentFirstPublishedDate": "2020-12-11T19:35:42.567Z",
     "mutectFirstPublishedDate": "2020-12-11T19:35:42.567Z",
     "rawReadsFirstPublishedDate": "2020-12-11T19:35:42.567Z",
-    "sangerVcsFirstPublishedDate": "2020-12-11T19:35:42.567Z"
+    "sangerVcsFirstPublishedDate": "2020-12-11T19:35:42.567Z",
+    "openAccessFirstPublishedDate": "2020-12-11T19:35:42.567Z"
   },
   {
     "publishedNormalAnalysis": 1,
@@ -297,6 +333,9 @@
     "mutectCompleted": 1,
     "mutectRunning": 0,
     "mutectFailed": 0,
+    "openAccessCompleted": 1,
+    "openAccessRunning": 0,
+    "openAccessFailed": 0,
     "totalFilesCount": 0,
     "filesToQcCount": 0,
     "releaseStatus": "NO_RELEASE",
@@ -315,6 +354,7 @@
     "alignmentFirstPublishedDate": "2020-12-11T19:35:42.567Z",
     "mutectFirstPublishedDate": "2020-12-11T19:35:42.567Z",
     "rawReadsFirstPublishedDate": "2020-12-11T19:35:42.567Z",
-    "sangerVcsFirstPublishedDate": "2020-12-11T19:35:42.567Z"
+    "sangerVcsFirstPublishedDate": "2020-12-11T19:35:42.567Z",
+    "openAccessFirstPublishedDate": "2020-12-11T19:35:42.567Z"
   }
 ]

--- a/compose/sample_schema.json
+++ b/compose/sample_schema.json
@@ -96,6 +96,18 @@
       "sangerVcsFirstPublishedDate": {
         "type": "date"
       },
+      "openAccessCompleted": {
+        "type": "byte"
+      },
+      "openAccessRunning": {
+        "type": "byte"
+      },
+      "openAccessFailed": {
+        "type": "byte"
+      },
+      "openAccessFirstPublishedDate": {
+        "type": "date"
+      },
       "processingStatus": {
         "type": "keyword"
       },

--- a/src/schemas/ProgramDonorPublishedAnalysisByDateRange/gqlTypeDefs.ts
+++ b/src/schemas/ProgramDonorPublishedAnalysisByDateRange/gqlTypeDefs.ts
@@ -62,6 +62,10 @@ export default gql`
     Timestamp of when this donor first had Sanger VC data published
     """
     sangerVcsFirstPublishedDate
+    """
+    Timestamp of when this donor first had Open Access data published
+    """
+    openAccessFirstPublishedDate
   }
 
   type Query {

--- a/src/schemas/ProgramDonorPublishedAnalysisByDateRange/resolvers/types.ts
+++ b/src/schemas/ProgramDonorPublishedAnalysisByDateRange/resolvers/types.ts
@@ -48,7 +48,8 @@ export type DonorFields =
   'coreCompletionDate' |
   'mutectFirstPublishedDate' |
   'rawReadsFirstPublishedDate' |
-  'sangerVcsFirstPublishedDate';
+  'sangerVcsFirstPublishedDate' |
+  'openAccessFirstPublishedDate';
 
 export type EsAggs = {
   [key in DonorFields]: EsAggsBuckets;

--- a/src/schemas/ProgramDonorSummary/gqlTypeDefs.ts
+++ b/src/schemas/ProgramDonorSummary/gqlTypeDefs.ts
@@ -81,6 +81,14 @@ export default gql`
     NO_DATA = donor has 0 of all the above Mutect 2 workflow.
     """
     mutectStatus
+    """
+    use this field to filter donor entries by 4 enum values: COMPLETED, IN_PROGRESS, FAILED, NO_DATA.
+    COMPLETED = donor has 1 or more completed Open Access workflow;
+    IN_PROGRESS = donor has 1 or more running Open Access workflow;
+    FAILED = donor has 1 or more failed Open Access workflow;
+    NO_DATA = donor has 0 of all the above Open Access workflow.
+    """
+    openAccessStatus
     validWithCurrentDictionary
     releaseStatus
     submitterDonorId
@@ -100,6 +108,9 @@ export default gql`
     mutectCompleted
     mutectRunning
     mutectFailed
+    openAccessCompleted
+    openAccessRunning
+    openAccessFailed
     processingStatus
     updatedAt
     createdAt
@@ -232,6 +243,18 @@ export default gql`
     """
     mutectFailed: Int!
     """
+    Number of Open Access completed for this donor
+    """
+    openAccessCompleted: Int!
+    """
+    Number of Open Access currently running for this donor
+    """
+    openAccessRunning: Int!
+    """
+    Number of Open Access that is failed for this donor
+    """
+    openAccessFailed: Int!
+    """
     Molecular data processing status of this donor
     """
     processingStatus: DonorMolecularDataProcessingStatus!
@@ -328,6 +351,11 @@ export default gql`
     Number of donors that have COMPLETED/IN_PROGRESS/FAILED/NO_DATA as mutect2 workflow status
     """
     mutectStatusCount: WorkflowStatusCount!
+
+    """
+    Number of donors that have COMPLETED/IN_PROGRESS/FAILED/NO_DATA as Open Access workflow status
+    """
+    openAccessStatusCount: WorkflowStatusCount!
 
     """
     Date of the most recent update to the donor summary index for this program. Can be null if no documents for this program

--- a/src/schemas/ProgramDonorSummary/resolvers/types.ts
+++ b/src/schemas/ProgramDonorSummary/resolvers/types.ts
@@ -59,6 +59,9 @@ export type DonorSummaryEntry = {
   mutectCompleted: number;
   mutectRunning: number;
   mutectFailed: number;
+  openAccessCompleted: number;
+  openAccessRunning: number;
+  openAccessFailed: number;
   processingStatus: DonorMolecularDataProcessingStatus;
   updatedAt: Date;
   createdAt: Date;
@@ -72,6 +75,7 @@ type ProgramDonorSummaryEntryField = keyof DonorSummaryEntry & keyof
     alignmentStatus: string,
     sangerVCStatus: string,
     mutectStatus: string,
+    openAccessStatus: string,
   };
 
 export type ProgramDonorSummaryFilter = {
@@ -106,6 +110,8 @@ export type ProgramDonorSummaryStats = {
   sangerStatusCount: WorkflowStatusCount;
 
   mutectStatusCount: WorkflowStatusCount;
+
+  openAccessStatusCount: WorkflowStatusCount;
 
   lastUpdate?: Date;
 };
@@ -159,6 +165,7 @@ export enum EsDonorDocumentField {
   alignmentStatus = 'alignmentStatus',
   sangerVCStatus = 'sangerVCStatus',
   mutectStatus = 'mutectStatus',
+  openAccessStatus = 'openAccessStatus',
   processingStatus = 'processingStatus',
   programId = 'programId',
   publishedNormalAnalysis = 'publishedNormalAnalysis',
@@ -172,6 +179,9 @@ export enum EsDonorDocumentField {
   mutectCompleted = 'mutectCompleted',
   mutectRunning = 'mutectRunning',
   mutectFailed = 'mutectFailed',
+  openAccessCompleted = 'openAccessCompleted',
+  openAccessRunning = 'openAccessRunning',
+  openAccessFailed = 'openAccessFailed',
   submittedCoreDataPercent = 'submittedCoreDataPercent',
   submittedExtendedDataPercent = 'submittedExtendedDataPercent',
   submitterDonorId = 'submitterDonorId',
@@ -200,6 +210,9 @@ export type ElasticsearchDonorDocument = {
   [EsDonorDocumentField.mutectCompleted]: number;
   [EsDonorDocumentField.mutectRunning]: number;
   [EsDonorDocumentField.mutectFailed]: number;
+  [EsDonorDocumentField.openAccessCompleted]: number;
+  [EsDonorDocumentField.openAccessRunning]: number;
+  [EsDonorDocumentField.openAccessFailed]: number;
   [EsDonorDocumentField.submittedCoreDataPercent]: number;
   [EsDonorDocumentField.submittedExtendedDataPercent]: number;
   [EsDonorDocumentField.submitterDonorId]: string;


### PR DESCRIPTION
**Description of changes**

* Exposes new fields related to Open Access workflows: `openAccessCompleted`, `openAccessRunning`, `openAccessFailed`, and `openAccessFirstPublishedDate`
* Also adds filters for donors by Open Access workflow status

**Type of Change**

- [ ] Bug
- [x] New Feature
