### PR TITLE
💥 Change Small File Download Logic (#500)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -92,7 +92,7 @@ export const RECAPTCHA_VAULT_SECRET_PATH = String(process.env.RECAPTCHA_VAULT_SE
 export const DEV_RECAPTCHA_DISABLED = process.env.DEV_RECAPTCHA_DISABLED === 'true';
 
 // File Storage API
-export const MAX_FILE_DOWNLOAD_SIZE = Number(process.env.MAX_FILE_DOWNLOAD_SIZE) || 100000000; // 100MB
+export const MAX_FILE_DOWNLOAD_SIZE = Number(process.env.MAX_FILE_DOWNLOAD_SIZE) || 5000000; // 5MB
 
 // TSV download configs
 export const DEFAULT_TSV_STREAM_CHUNK_SIZE =

--- a/src/resources/swagger/file-storage-api.yaml
+++ b/src/resources/swagger/file-storage-api.yaml
@@ -169,13 +169,13 @@ paths:
           description: Forbidden
         "404":
           description: Not Found
-  "/storage-api/get-download-url/{id}":
+  "/storage-api/download-file/{id}":
     get:
       security:
         - bearerAuth: []
       tags:
         - File Storage Api
-      summary: Fetch public download URL for small file downloads directly from object storage
+      summary: Download small files directly from object storage
       parameters:
         - name: id
           in: path

--- a/src/routes/file-storage-api/handlers/downloadHandler.ts
+++ b/src/routes/file-storage-api/handlers/downloadHandler.ts
@@ -178,9 +178,6 @@ export const downloadFile = ({
             return res.status(500).end();
           });
         })
-        .then(() => {
-          return res.status(200).end();
-        })
         .catch(err => {
           logger.error('Score Download Error - ' + err);
           return res.status(500).end();

--- a/src/routes/file-storage-api/index.ts
+++ b/src/routes/file-storage-api/index.ts
@@ -21,7 +21,7 @@ import { Client } from '@elastic/elasticsearch';
 import express, { Router } from 'express';
 import urljoin from 'url-join';
 import { ADVERTISED_HOST } from 'config';
-import downloadProxy, { getDownloadUrl } from './handlers/downloadHandler';
+import downloadProxy, { downloadFile } from './handlers/downloadHandler';
 import createEntitiesHandler from './handlers/entitiesHandler';
 import createEntitiesIdHandler from './handlers/entitiesIdHandler';
 import authenticatedRequestMiddleware from 'routes/middleware/authenticatedRequestMiddleware';
@@ -81,9 +81,9 @@ export default async ({
     }),
   );
   router.get(
-    '/get-download-url/:fileObjectId',
+    '/download-file/:fileObjectId',
     authenticatedRequestMiddleware({ egoClient }),
-    getDownloadUrl({
+    downloadFile({
       esClient,
       scoreAuthClient,
     }),


### PR DESCRIPTION
**Description of changes**

Download files from object storage and pipe them to the client with the expected filename, instead of forwarding the download URL. Changes `/storage-api/get-download-url` endpoint to `/storage-api/download-file`, and sets the download file size limit to 5MB.

**Commits:**

🔧 Set Default Limit For Small File Downloads to 5MB 

 💥 Change Small File Download Logic

* Download files from object storage and pipe them to the client instead of forwarding the download URL
* Set the filename for the piped file using the `content-disposition` header

**Type of Change**

- [ ] Bug
- [x] New Feature
