### PR TITLE
Kafka Proxy Payload Size set to 1Mb

### DIFF
--- a/src/routes/kafka-rest-proxy.ts
+++ b/src/routes/kafka-rest-proxy.ts
@@ -58,6 +58,7 @@ const createKafkaRouter = (egoClient: EgoClient): Router => {
     });
     if (!hasPermission) {
       res.status(403).json({ error: 'not authorized' });
+      return;
     }
 
     const url = urlJoin(apiRoot, 'topics', topic);
@@ -70,7 +71,7 @@ const createKafkaRouter = (egoClient: EgoClient): Router => {
         },
       ],
     });
-    return await fetch(url, {
+    await fetch(url, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/vnd.kafka.json.v2+json',
@@ -81,12 +82,15 @@ const createKafkaRouter = (egoClient: EgoClient): Router => {
       .then(response => {
         res.contentType('application/vnd.kafka.v2+json');
         res.status(response.status);
-        return response.body.pipe(res);
+        response.body.pipe(res);
+        return;
       })
       .catch(e => {
         logger.error('failed to send message to kafka proxy' + e);
-        return res.status(500).send(e);
+        res.status(500).send(e);
+        return;
       });
+    return;
   });
 
   return router;

--- a/src/routes/kafka-rest-proxy.ts
+++ b/src/routes/kafka-rest-proxy.ts
@@ -34,7 +34,8 @@ const createKafkaRouter = (egoClient: EgoClient): Router => {
   const apiRoot = KAFKA_REST_PROXY_ROOT;
 
   // fetch needs to use the json body parser
-  router.use(json());
+  // Kafka can accept message up to max 1mb in size, and there are examples of song sending messages larger than the default 100kb limit
+  router.use(json({ limit: '1mb' }));
 
   router.use(authenticatedRequestMiddleware({ egoClient }));
 


### PR DESCRIPTION
**Description of changes**
Sets the json payload size to 1Mb for the kafka proxy endpoint. This is the max message size accepted by kafka. Song is sending messages that are larger than the default body-parser 100kb limit.

**Type of Change**

- [x] Bug
- [ ] New Feature
