### PR TITLE
#610: fix DNA raw reads filter

### DIFF
--- a/src/schemas/ProgramDonorSummary/resolvers/summaryEntriesAndStats.ts
+++ b/src/schemas/ProgramDonorSummary/resolvers/summaryEntriesAndStats.ts
@@ -572,12 +572,19 @@ const programDonorSummaryEntriesAndStatsResolver: (esClient: Client) => DonorEnt
 					esb.rangeQuery().field(EsDonorDocumentField.matchedTNPairsDNA).gte(1),
 				),
 				filterAggregation('noDnaTNMatchedPairsSubmitted' as AggregationName).filter(
+					// no matched pairs, and at least 1 T or N
 					esb
 						.boolQuery()
-						.must([esb.rangeQuery().field(EsDonorDocumentField.matchedTNPairsDNA).lte(0)])
-						.should([
-							esb.rangeQuery().field(EsDonorDocumentField.publishedNormalAnalysis).gte(1),
-							esb.rangeQuery().field(EsDonorDocumentField.publishedTumourAnalysis).gte(1),
+						.must([
+							esb
+								.boolQuery()
+								.must([esb.rangeQuery().field(EsDonorDocumentField.matchedTNPairsDNA).lte(0)]),
+							esb
+								.boolQuery()
+								.should([
+									esb.rangeQuery().field(EsDonorDocumentField.publishedNormalAnalysis).gte(1),
+									esb.rangeQuery().field(EsDonorDocumentField.publishedTumourAnalysis).gte(1),
+								]),
 						]),
 				),
 				filterAggregation('noDnaTNMatchedPairsData' as AggregationName).filter(


### PR DESCRIPTION
**Description of changes**

Wrap the DNA raw reads (no matched pairs & some data submitted) filter in a `must()` condition.

**Type of Change**

- [x] Bug
- [ ] New Feature
