### PR TITLE
Accessing Program Service HTTP Public Endpoint 

### DIFF
--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -34,7 +34,7 @@ services:
     depends_on:
       - program-db
     environment:
-      # SPRING_PROFILES_ACTIVE: 'auth'
+      SPRING_PROFILES_ACTIVE: 'auth'
       SPRING_DATASOURCE_URL: 'jdbc:postgresql://program-db:5432/program-db?stringtype=unspecified'
       SPRING_DATASOURCE_USERNAME: postgres
       SPRING_DATASOURCE_PASSWORD: password

--- a/src/config.ts
+++ b/src/config.ts
@@ -68,6 +68,7 @@ export const EGO_PUBLIC_KEY =
 
 // External service root
 export const PROGRAM_SERVICE_ROOT = process.env.PROGRAM_SERVICE_ROOT || 'localhost:50052';
+export const PROGRAM_SERVICE_HTTP_ROOT = process.env.PROGRAM_SERVICE_HTTP_ROOT || 'localhost:8083';
 export const CLINICAL_SERVICE_ROOT = process.env.CLINICAL_SERVICE_ROOT || 'http://localhost:3000';
 export const KAFKA_REST_PROXY_ROOT = process.env.KAFKA_REST_PROXY_ROOT || 'http://localhost:8085';
 export const DONOR_AGGREGATOR_API_ROOT =

--- a/src/schemas/Program/index.js
+++ b/src/schemas/Program/index.js
@@ -251,7 +251,9 @@ const resolveProgramList = async (egoToken) => {
 
 const resolveSingleProgram = async (egoToken, programShortName) => {
 	const response = await programService.getProgram(programShortName, egoToken);
+
 	const programDetails = get(response, 'program');
+	console.log('full response', programDetails);
 	return response ? convertGrpcProgramToGql(programDetails) : null;
 };
 
@@ -303,6 +305,11 @@ const resolvers = {
 	},
 	Query: {
 		program: async (obj, args, context, info) => {
+			const requestedFields = info.fieldNodes.flatMap((fieldNode) =>
+				fieldNode.selectionSet.selections.map((selection) => selection.name.value),
+			);
+			console.log('request', JSON.stringify({ obj, args, context, info }));
+			console.log('requested fields', requestedFields);
 			const { egoToken } = context;
 			const { shortName } = args;
 			return resolveSingleProgram(egoToken, shortName);

--- a/src/schemas/Program/index.js
+++ b/src/schemas/Program/index.js
@@ -331,20 +331,6 @@ const resolvers = {
 				: resolveHTTPProgram(shortName);
 		},
 
-		// clinicalRegistration: async (
-		// 	obj: unknown,
-		// 	args: { shortName: string },
-		// 	context: GlobalGqlContext,
-		// ) => {
-		// 	const { Authorization } = context;
-		// 	const { shortName } = args;
-
-		// 	const response = await clinicalService.getRegistrationData(shortName, Authorization);
-		// 	return convertRegistrationDataToGql(shortName, {
-		// 		registration: response,
-		// 	});
-		// }
-
 		programs: async (obj, args, context, info) => {
 			const { egoToken } = context;
 			return resolveProgramList(egoToken);

--- a/src/services/programService/grpcClient.js
+++ b/src/services/programService/grpcClient.js
@@ -1,0 +1,354 @@
+/*
+ * Copyright (c) 2022 The Ontario Institute for Cancer Research. All rights reserved
+ *
+ * This program and the accompanying materials are made available under the terms of
+ * the GNU Affero General Public License v3.0. You should have received a copy of the
+ * GNU Affero General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * This file dynamically generates a gRPC client from Ego.proto.
+ * The content of Ego.proto is copied directly from: https://github.com/icgc-argo/argo-proto/blob/4e2aeda59eb48b7af20b462aef2f04ef5d0d6e7c/ProgramService.proto
+ */
+
+import { get } from 'lodash';
+import grpc from 'grpc';
+import * as loader from '@grpc/proto-loader';
+import protoPath from '@icgc-argo/program-service-proto';
+
+import { PROGRAM_SERVICE_ROOT } from '../../config';
+import { getAuthMeta, wrapValue, withRetries, defaultPromiseCallback } from '../../utils/grpcUtils';
+import retry from 'retry';
+
+const packageDefinition = loader.loadSync(protoPath, {
+	keepCase: true,
+	longs: String,
+	enums: String,
+	defaults: true,
+	oneofs: true,
+});
+
+const proto = grpc.loadPackageDefinition(packageDefinition).program_service;
+
+/**
+ * this config was taken from: https://cs.mcgill.ca/~mxia3/2019/02/23/Using-gRPC-in-Production/
+ */
+const GRPC_CONFIG = {
+	'grpc.keepalive_time_ms': 10000,
+	'grpc.keepalive_timeout_ms': 5000,
+	'grpc.keepalive_permit_without_calls': 1,
+	'grpc.http2.max_pings_without_data': 0,
+	'grpc.http2.min_time_between_pings_ms': 10000,
+	'grpc.http2.min_ping_interval_without_data_ms': 5000,
+};
+const programServiceRegex = RegExp(/:443$/);
+const programServiceGrpcClient = withRetries(
+	programServiceRegex.test(PROGRAM_SERVICE_ROOT)
+		? new proto.ProgramService(PROGRAM_SERVICE_ROOT, grpc.credentials.createSsl(), GRPC_CONFIG)
+		: new proto.ProgramService(
+				PROGRAM_SERVICE_ROOT,
+				grpc.credentials.createInsecure(),
+				GRPC_CONFIG,
+		  ),
+);
+
+/*
+ * GPRC Read-only Methods
+ */
+const getProgram = async (shortName, jwt = null) => {
+	return await new Promise((resolve, reject) => {
+		programServiceGrpcClient.getProgram(
+			{ short_name: wrapValue(shortName) },
+			getAuthMeta(jwt),
+			defaultPromiseCallback(resolve, reject, 'ProgramService.getProgram'),
+		);
+	});
+};
+
+const getJoinProgramInvite = async (id, jwt = null) => {
+	return await new Promise((resolve, reject) => {
+		programServiceGrpcClient.getJoinProgramInvite(
+			{ invite_id: wrapValue(id) },
+			getAuthMeta(jwt),
+			defaultPromiseCallback(resolve, reject, 'ProgramService.getJoinProgramInvite'),
+		);
+	});
+};
+
+const listPrograms = async (jwt = null) => {
+	return await new Promise((resolve, reject) => {
+		programServiceGrpcClient.listPrograms(
+			{},
+			getAuthMeta(jwt),
+			defaultPromiseCallback(resolve, reject, 'ProgramService.listPrograms'),
+		);
+	});
+};
+
+const listUsers = async (shortName, jwt = null) => {
+	return await new Promise((resolve, reject) => {
+		programServiceGrpcClient.listUsers(
+			{ program_short_name: wrapValue(shortName) },
+			getAuthMeta(jwt),
+			defaultPromiseCallback(resolve, reject, 'ProgramService.listUsers'),
+		);
+	});
+};
+
+/* Read Options Lists */
+const listCountries = async (jwt = null) => {
+	return await new Promise((resolve, reject) => {
+		programServiceGrpcClient.listCountries(
+			{},
+			getAuthMeta(jwt),
+			defaultPromiseCallback(resolve, reject, 'ProgramService.listCountries'),
+		);
+	});
+};
+
+const listCancers = async (jwt = null) => {
+	return await new Promise((resolve, reject) => {
+		programServiceGrpcClient.listCancers(
+			{},
+			getAuthMeta(jwt),
+			defaultPromiseCallback(resolve, reject, 'ProgramService.listCancers'),
+		);
+	});
+};
+
+const listPrimarySites = async (jwt = null) => {
+	return await new Promise((resolve, reject) => {
+		programServiceGrpcClient.listPrimarySites(
+			{},
+			getAuthMeta(jwt),
+			defaultPromiseCallback(resolve, reject, 'ProgramService.listPrimarySites'),
+		);
+	});
+};
+
+const listRegions = async (jwt = null) => {
+	return await new Promise((resolve, reject) => {
+		programServiceGrpcClient.listRegions(
+			{},
+			getAuthMeta(jwt),
+			defaultPromiseCallback(resolve, reject, 'ProgramService.listRegions'),
+		);
+	});
+};
+
+const listInstitutions = async (jwt = null) => {
+	return await new Promise((resolve, reject) => {
+		programServiceGrpcClient.listInstitutions(
+			{},
+			getAuthMeta(jwt),
+			defaultPromiseCallback(resolve, reject, 'ProgramService.listInstitutions'),
+		);
+	});
+};
+
+/*
+ * Mutating Methods
+ */
+const createProgram = async (
+	{
+		name,
+		shortName,
+		description,
+		commitmentDonors,
+		submittedDonors,
+		genomicDonors,
+		website,
+		institutions,
+		countries,
+		regions,
+		membershipType,
+		cancerTypes,
+		primarySites,
+		admins,
+	},
+	jwt = null,
+) => {
+	const createProgramRequest = {
+		program: {
+			name: wrapValue(name),
+			short_name: wrapValue(shortName),
+			description: wrapValue(description),
+			commitment_donors: wrapValue(commitmentDonors),
+			submitted_donors: wrapValue(submittedDonors),
+			genomic_donors: wrapValue(genomicDonors),
+			website: wrapValue(website),
+
+			institutions: institutions,
+			countries: countries,
+			regions: regions,
+			cancer_types: cancerTypes,
+			primary_sites: primarySites,
+
+			membership_type: wrapValue(membershipType),
+		},
+		admins: (admins || []).map((admin) => ({
+			email: wrapValue(get(admin, 'email')),
+			first_name: wrapValue(get(admin, 'firstName')),
+			last_name: wrapValue(get(admin, 'lastName')),
+			role: wrapValue(get(admin, 'role')),
+		})),
+	};
+
+	return await new Promise((resolve, reject) => {
+		programServiceGrpcClient.createProgram(
+			createProgramRequest,
+			getAuthMeta(jwt),
+			defaultPromiseCallback(resolve, reject, 'ProgramService.createProgram'),
+		);
+	});
+};
+
+const updateProgram = async (
+	shortName,
+	{
+		name,
+		description,
+		commitmentDonors,
+		submittedDonors,
+		genomicDonors,
+		website,
+		institutions,
+		countries,
+		regions,
+		membershipType,
+		cancerTypes,
+		primarySites,
+	},
+	jwt = null,
+) => {
+	const updateProgramRequest = {
+		program: {
+			short_name: wrapValue(shortName),
+			name: wrapValue(name),
+			description: wrapValue(description),
+			commitment_donors: wrapValue(commitmentDonors),
+			website: wrapValue(website),
+			submitted_donors: wrapValue(submittedDonors),
+			genomic_donors: wrapValue(genomicDonors),
+
+			institutions: institutions,
+			countries: countries,
+			regions: regions,
+			cancer_types: cancerTypes,
+			primary_sites: primarySites,
+
+			membership_type: wrapValue(membershipType),
+		},
+	};
+
+	return await new Promise((resolve, reject) => {
+		programServiceGrpcClient.updateProgram(
+			updateProgramRequest,
+			getAuthMeta(jwt),
+			defaultPromiseCallback(resolve, reject, 'ProgramService.updateProgram'),
+		);
+	});
+};
+
+const inviteUser = async (
+	{ programShortName, userFirstName, userLastName, userEmail, userRole },
+	jwt = null,
+) => {
+	const inviteUserRequest = {
+		program_short_name: wrapValue(programShortName),
+		first_name: wrapValue(userFirstName),
+		last_name: wrapValue(userLastName),
+		email: wrapValue(userEmail),
+		role: wrapValue(userRole),
+	};
+
+	return await new Promise((resolve, reject) => {
+		programServiceGrpcClient.inviteUser(
+			inviteUserRequest,
+			getAuthMeta(jwt),
+			defaultPromiseCallback(resolve, reject, 'ProgramService.inviteUser'),
+		);
+	});
+};
+
+const joinProgram = async (
+	{ invitationId, institute, piFirstName, piLastName, department },
+	jwt = null,
+) => {
+	const inviteUserRequest = {
+		join_program_invitation_id: wrapValue(invitationId),
+		institute: wrapValue(institute),
+		affiliate_pi_first_name: wrapValue(piFirstName),
+		affiliate_pi_last_name: wrapValue(piLastName),
+		department: wrapValue(department),
+	};
+
+	return await new Promise((resolve, reject) => {
+		programServiceGrpcClient.joinProgram(
+			inviteUserRequest,
+			getAuthMeta(jwt),
+			defaultPromiseCallback(resolve, reject, 'ProgramService.joinProgram'),
+		);
+	});
+};
+
+const updateUser = async (email, shortName, role, jwt = null) => {
+	const updateUserRequest = {
+		user_email: wrapValue(email),
+		role: wrapValue(role),
+		short_name: wrapValue(shortName),
+	};
+
+	return await new Promise((resolve, reject) => {
+		programServiceGrpcClient.updateUser(
+			updateUserRequest,
+			getAuthMeta(jwt),
+			defaultPromiseCallback(resolve, reject, 'ProgramService.updateUser'),
+		);
+	});
+};
+
+const removeUser = async (email, shortName, jwt = null) => {
+	const removeUserRequest = {
+		user_email: wrapValue(email),
+		program_short_name: wrapValue(shortName),
+	};
+
+	return await new Promise((resolve, reject) => {
+		programServiceGrpcClient.removeUser(
+			removeUserRequest,
+			getAuthMeta(jwt),
+			defaultPromiseCallback(resolve, reject, 'ProgramService.removeUser'),
+		);
+	});
+};
+
+// const inviteUser = async ({programShortName, }, jwt=null)
+export {
+	getProgram,
+	listPrograms,
+	getJoinProgramInvite,
+	listUsers,
+	listCancers,
+	listPrimarySites,
+	listRegions,
+	listInstitutions,
+	listCountries,
+	createProgram,
+	updateProgram,
+	inviteUser,
+	joinProgram,
+	updateUser,
+	removeUser,
+};

--- a/src/services/programService/httpClient.js
+++ b/src/services/programService/httpClient.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 The Ontario Institute for Cancer Research. All rights reserved
+ * Copyright (c) 2022 The Ontario Institute for Cancer Research. All rights reserved
  *
  * This program and the accompanying materials are made available under the terms of
  * the GNU Affero General Public License v3.0. You should have received a copy of the
@@ -22,27 +22,18 @@
  * The content of Ego.proto is copied directly from: https://github.com/icgc-argo/argo-proto/blob/4e2aeda59eb48b7af20b462aef2f04ef5d0d6e7c/ProgramService.proto
  */
 
-import * as grpc from './grpcClient.js';
-import * as http from './httpClient.js';
+const { PROGRAM_SERVICE_HTTP_ROOT } = require('config');
+import fetch from 'node-fetch';
+import { restErrorResponseHandler } from '../../utils/restUtils';
 
-export default {
-	getProgram: grpc.getProgram,
-	getProgramPublicFields: http.getProgramPublicFields,
-	listPrograms: grpc.listPrograms,
-	getJoinProgramInvite: grpc.getJoinProgramInvite,
-	listUsers: grpc.listUsers,
-
-	listCancers: grpc.listCancers,
-	listPrimarySites: grpc.listPrimarySites,
-	listRegions: grpc.listRegions,
-	listInstitutions: grpc.listInstitutions,
-	listCountries: grpc.listCountries,
-
-	createProgram: grpc.createProgram,
-	updateProgram: grpc.updateProgram,
-
-	inviteUser: grpc.inviteUser,
-	joinProgram: grpc.joinProgram,
-	updateUser: grpc.updateUser,
-	removeUser: grpc.removeUser,
+const getProgramPublicFields = async (programShortName) => {
+	const url = `${PROGRAM_SERVICE_HTTP_ROOT}/public/program?name=${programShortName}`;
+	const response = await fetch(url, {
+		method: 'get',
+	})
+		.then(restErrorResponseHandler)
+		.then((response) => response.json());
+	return response;
 };
+
+export { getProgramPublicFields };

--- a/src/services/programService/httpClient.js
+++ b/src/services/programService/httpClient.js
@@ -24,14 +24,14 @@
 
 const { PROGRAM_SERVICE_HTTP_ROOT } = require('config');
 import fetch from 'node-fetch';
-import { restErrorResponseHandler } from '../../utils/restUtils';
+import { programServicePublicErrorResponseHandler } from '../../utils/restUtils';
 
 const getProgramPublicFields = async (programShortName) => {
 	const url = `${PROGRAM_SERVICE_HTTP_ROOT}/public/program?name=${programShortName}`;
 	const response = await fetch(url, {
 		method: 'get',
 	})
-		.then(restErrorResponseHandler)
+		.then(programServicePublicErrorResponseHandler)
 		.then((response) => response.json());
 	return response;
 };

--- a/src/services/programService/index.js
+++ b/src/services/programService/index.js
@@ -27,7 +27,6 @@ import * as http from './httpClient.js';
 
 export default {
 	getProgram: grpc.getProgram,
-	getProgramPublicFields: http.getProgramPublicFields,
 	listPrograms: grpc.listPrograms,
 	getJoinProgramInvite: grpc.getJoinProgramInvite,
 	listUsers: grpc.listUsers,
@@ -45,4 +44,6 @@ export default {
 	joinProgram: grpc.joinProgram,
 	updateUser: grpc.updateUser,
 	removeUser: grpc.removeUser,
+
+	getProgramPublicFields: http.getProgramPublicFields,
 };


### PR DESCRIPTION
**Description of changes**

Connecting to Program Service's HTTP endpoints by creating a new resolver and error handler. The HTTP endpoints are public. The original endpoints (GRPC) needs authentication. The system will check whether the query contains info that are all public. If that's the case, automatically, the HTTP endpoints is used. And this could be done without auth.

Vice versa, if a query contain private info, then GRPC endpoints are used and this would require auth. 

**Type of Change**

- [ ] Bug
- [x] New Feature
