### PR TITLE
Update Clinical Data/Error/Search to use POST

### DIFF
--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '3'
 services:
   elasticsearch:
-    image: 'elasticsearch:7.5.0'
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.10.2
     ports:
       - 9200:9200
     volumes:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "server",
-	"version": "3.39.0",
+	"version": "3.39.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "server",
-			"version": "3.39.0",
+			"version": "3.39.1",
 			"license": "ISC",
 			"dependencies": {
 				"@arranger/server": "^2.18.2",
@@ -97,6 +97,7 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
 			"integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
+			"dev": true,
 			"dependencies": {
 				"@jridgewell/gen-mapping": "^0.1.0",
 				"@jridgewell/trace-mapping": "^0.3.9"
@@ -413,6 +414,7 @@
 			"version": "7.16.7",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
 			"integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
+			"dev": true,
 			"dependencies": {
 				"@babel/highlight": "^7.16.7"
 			},
@@ -432,6 +434,7 @@
 			"version": "7.18.5",
 			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.5.tgz",
 			"integrity": "sha512-MGY8vg3DxMnctw0LdvSEojOsumc70g0t18gNyUdAZqB1Rpd1Bqo/svHGvt+UJ6JcGX+DIekGFDxxIWofBxLCnQ==",
+			"dev": true,
 			"dependencies": {
 				"@ampproject/remapping": "^2.1.0",
 				"@babel/code-frame": "^7.16.7",
@@ -462,6 +465,7 @@
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
 			"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 			"deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
+			"dev": true,
 			"dependencies": {
 				"ms": "^2.1.1"
 			}
@@ -469,12 +473,14 @@
 		"node_modules/@babel/core/node_modules/ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+			"dev": true
 		},
 		"node_modules/@babel/core/node_modules/semver": {
 			"version": "6.3.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
 			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+			"dev": true,
 			"bin": {
 				"semver": "bin/semver.js"
 			}
@@ -483,6 +489,7 @@
 			"version": "7.18.2",
 			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.2.tgz",
 			"integrity": "sha512-W1lG5vUwFvfMd8HVXqdfbuG7RuaSrTCCD8cl8fP8wOivdbtbIg2Db3IWUcgvfxKbbn6ZBGYRW/Zk1MIwK49mgw==",
+			"dev": true,
 			"dependencies": {
 				"@babel/types": "^7.18.2",
 				"@jridgewell/gen-mapping": "^0.3.0",
@@ -496,6 +503,7 @@
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.1.tgz",
 			"integrity": "sha512-GcHwniMlA2z+WFPWuY8lp3fsza0I8xPFMWL5+n8LYyP6PSvPrXf4+n8stDHZY2DM0zy9sVkRDy1jDI4XGzYVqg==",
+			"dev": true,
 			"dependencies": {
 				"@jridgewell/set-array": "^1.0.0",
 				"@jridgewell/sourcemap-codec": "^1.4.10",
@@ -647,6 +655,7 @@
 			"version": "7.18.2",
 			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.2.tgz",
 			"integrity": "sha512-14GQKWkX9oJzPiQQ7/J36FTXcD4kSp8egKjO9nINlSKiHITRA9q/R74qu8S9xlc/b/yjsJItQUeeh3xnGN0voQ==",
+			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -667,6 +676,7 @@
 			"version": "7.17.9",
 			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.17.9.tgz",
 			"integrity": "sha512-7cRisGlVtiVqZ0MW0/yFB4atgpGLWEHUVYnb448hZK4x+vih0YO5UoS11XIYtZYqHd0dIPMdUSv8q5K4LdMnIg==",
+			"dev": true,
 			"dependencies": {
 				"@babel/template": "^7.16.7",
 				"@babel/types": "^7.17.0"
@@ -679,6 +689,7 @@
 			"version": "7.16.7",
 			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz",
 			"integrity": "sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==",
+			"dev": true,
 			"dependencies": {
 				"@babel/types": "^7.16.7"
 			},
@@ -702,6 +713,7 @@
 			"version": "7.16.7",
 			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz",
 			"integrity": "sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==",
+			"dev": true,
 			"dependencies": {
 				"@babel/types": "^7.16.7"
 			},
@@ -713,6 +725,7 @@
 			"version": "7.18.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.18.0.tgz",
 			"integrity": "sha512-kclUYSUBIjlvnzN2++K9f2qzYKFgjmnmjwL4zlmU5f8ZtzgWe8s0rUPSTGy2HmK4P8T52MQsS+HTQAgZd3dMEA==",
+			"dev": true,
 			"dependencies": {
 				"@babel/helper-environment-visitor": "^7.16.7",
 				"@babel/helper-module-imports": "^7.16.7",
@@ -781,6 +794,7 @@
 			"version": "7.18.2",
 			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.18.2.tgz",
 			"integrity": "sha512-7LIrjYzndorDY88MycupkpQLKS1AFfsVRm2k/9PtKScSy5tZq0McZTj+DiMRynboZfIqOKvo03pmhTaUgiD6fQ==",
+			"dev": true,
 			"dependencies": {
 				"@babel/types": "^7.18.2"
 			},
@@ -803,6 +817,7 @@
 			"version": "7.16.7",
 			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.7.tgz",
 			"integrity": "sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==",
+			"dev": true,
 			"dependencies": {
 				"@babel/types": "^7.16.7"
 			},
@@ -845,6 +860,7 @@
 			"version": "7.18.2",
 			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.18.2.tgz",
 			"integrity": "sha512-j+d+u5xT5utcQSzrh9p+PaJX94h++KN+ng9b9WEJq7pkUPAd61FGqhjuUEdfknb3E/uDBb7ruwEeKkIxNJPIrg==",
+			"dev": true,
 			"dependencies": {
 				"@babel/template": "^7.16.7",
 				"@babel/traverse": "^7.18.2",
@@ -858,6 +874,7 @@
 			"version": "7.17.12",
 			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.17.12.tgz",
 			"integrity": "sha512-7yykMVF3hfZY2jsHZEEgLc+3x4o1O+fYyULu11GynEUQNwB6lua+IIQn1FiJxNucd5UlyJryrwsOh8PL9Sn8Qg==",
+			"dev": true,
 			"dependencies": {
 				"@babel/helper-validator-identifier": "^7.16.7",
 				"chalk": "^2.0.0",
@@ -871,6 +888,7 @@
 			"version": "7.18.5",
 			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.5.tgz",
 			"integrity": "sha512-YZWVaglMiplo7v8f1oMQ5ZPQr0vn7HPeZXxXWsxXJRjGVrzUFn9OxFQl1sb5wzfootjA/yChhW84BV+383FSOw==",
+			"dev": true,
 			"bin": {
 				"parser": "bin/babel-parser.js"
 			},
@@ -2031,6 +2049,7 @@
 			"version": "7.16.7",
 			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.7.tgz",
 			"integrity": "sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==",
+			"dev": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.16.7",
 				"@babel/parser": "^7.16.7",
@@ -2044,6 +2063,7 @@
 			"version": "7.18.5",
 			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.5.tgz",
 			"integrity": "sha512-aKXj1KT66sBj0vVzk6rEeAO6Z9aiiQ68wfDgge3nHhA/my6xMM/7HGQUNumKZaoa2qUPQ5whJG9aAifsxUKfLA==",
+			"dev": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.16.7",
 				"@babel/generator": "^7.18.2",
@@ -2065,6 +2085,7 @@
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
 			"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 			"deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
+			"dev": true,
 			"dependencies": {
 				"ms": "^2.1.1"
 			}
@@ -2072,7 +2093,8 @@
 		"node_modules/@babel/traverse/node_modules/ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+			"dev": true
 		},
 		"node_modules/@babel/types": {
 			"version": "7.18.8",
@@ -3209,6 +3231,7 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
 			"integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
+			"dev": true,
 			"dependencies": {
 				"@jridgewell/set-array": "^1.0.0",
 				"@jridgewell/sourcemap-codec": "^1.4.10"
@@ -3221,6 +3244,7 @@
 			"version": "3.0.7",
 			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.7.tgz",
 			"integrity": "sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==",
+			"dev": true,
 			"engines": {
 				"node": ">=6.0.0"
 			}
@@ -3229,6 +3253,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.1.tgz",
 			"integrity": "sha512-Ct5MqZkLGEXTVmQYbGtx9SVqD2fqwvdubdps5D3djjAkgkKwT918VNOz65pEHFaYTeWcukmJmH5SwsA9Tn2ObQ==",
+			"dev": true,
 			"engines": {
 				"node": ">=6.0.0"
 			}
@@ -3236,12 +3261,14 @@
 		"node_modules/@jridgewell/sourcemap-codec": {
 			"version": "1.4.13",
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz",
-			"integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w=="
+			"integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==",
+			"dev": true
 		},
 		"node_modules/@jridgewell/trace-mapping": {
 			"version": "0.3.13",
 			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.13.tgz",
 			"integrity": "sha512-o1xbKhp9qnIAoHJSWd6KlCZfqslL4valSF81H8ImioOAxluWYWOpWkpyktY2vnt4tbrX9XYaxovq6cgowaJp2w==",
+			"dev": true,
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.0.3",
 				"@jridgewell/sourcemap-codec": "^1.4.10"
@@ -5966,6 +5993,7 @@
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
 			"integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+			"dev": true,
 			"dependencies": {
 				"safe-buffer": "~5.1.1"
 			}
@@ -8364,6 +8392,7 @@
 			"version": "1.0.0-beta.2",
 			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
 			"integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -8509,6 +8538,7 @@
 			"version": "11.12.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
 			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+			"dev": true,
 			"engines": {
 				"node": ">=4"
 			}
@@ -11920,7 +11950,8 @@
 		"node_modules/js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+			"dev": true
 		},
 		"node_modules/js-yaml": {
 			"version": "3.13.1",
@@ -12016,6 +12047,7 @@
 			"version": "2.5.2",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
 			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+			"dev": true,
 			"bin": {
 				"jsesc": "bin/jsesc"
 			},
@@ -12062,6 +12094,7 @@
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
 			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+			"dev": true,
 			"bin": {
 				"json5": "lib/cli.js"
 			},
@@ -17130,6 +17163,7 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
 			"integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
+			"dev": true,
 			"requires": {
 				"@jridgewell/gen-mapping": "^0.1.0",
 				"@jridgewell/trace-mapping": "^0.3.9"
@@ -17165,8 +17199,7 @@
 		"@apollographql/apollo-tools": {
 			"version": "0.5.4",
 			"resolved": "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.5.4.tgz",
-			"integrity": "sha512-shM3q7rUbNyXVVRkQJQseXv6bnYM3BUma/eZhwXR4xsuM+bqWnJKvW7SAfRjP7LuSCocrexa5AXhjjawNHrIlw==",
-			"requires": {}
+			"integrity": "sha512-shM3q7rUbNyXVVRkQJQseXv6bnYM3BUma/eZhwXR4xsuM+bqWnJKvW7SAfRjP7LuSCocrexa5AXhjjawNHrIlw=="
 		},
 		"@apollographql/graphql-playground-html": {
 			"version": "1.6.27",
@@ -17396,6 +17429,7 @@
 			"version": "7.16.7",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
 			"integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
+			"dev": true,
 			"requires": {
 				"@babel/highlight": "^7.16.7"
 			}
@@ -17409,6 +17443,7 @@
 			"version": "7.18.5",
 			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.5.tgz",
 			"integrity": "sha512-MGY8vg3DxMnctw0LdvSEojOsumc70g0t18gNyUdAZqB1Rpd1Bqo/svHGvt+UJ6JcGX+DIekGFDxxIWofBxLCnQ==",
+			"dev": true,
 			"requires": {
 				"@ampproject/remapping": "^2.1.0",
 				"@babel/code-frame": "^7.16.7",
@@ -17431,6 +17466,7 @@
 					"version": "4.1.1",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
 					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
 					}
@@ -17438,12 +17474,14 @@
 				"ms": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
 				},
 				"semver": {
 					"version": "6.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
 				}
 			}
 		},
@@ -17451,6 +17489,7 @@
 			"version": "7.18.2",
 			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.2.tgz",
 			"integrity": "sha512-W1lG5vUwFvfMd8HVXqdfbuG7RuaSrTCCD8cl8fP8wOivdbtbIg2Db3IWUcgvfxKbbn6ZBGYRW/Zk1MIwK49mgw==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "^7.18.2",
 				"@jridgewell/gen-mapping": "^0.3.0",
@@ -17461,6 +17500,7 @@
 					"version": "0.3.1",
 					"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.1.tgz",
 					"integrity": "sha512-GcHwniMlA2z+WFPWuY8lp3fsza0I8xPFMWL5+n8LYyP6PSvPrXf4+n8stDHZY2DM0zy9sVkRDy1jDI4XGzYVqg==",
+					"dev": true,
 					"requires": {
 						"@jridgewell/set-array": "^1.0.0",
 						"@jridgewell/sourcemap-codec": "^1.4.10",
@@ -17573,7 +17613,8 @@
 		"@babel/helper-environment-visitor": {
 			"version": "7.18.2",
 			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.2.tgz",
-			"integrity": "sha512-14GQKWkX9oJzPiQQ7/J36FTXcD4kSp8egKjO9nINlSKiHITRA9q/R74qu8S9xlc/b/yjsJItQUeeh3xnGN0voQ=="
+			"integrity": "sha512-14GQKWkX9oJzPiQQ7/J36FTXcD4kSp8egKjO9nINlSKiHITRA9q/R74qu8S9xlc/b/yjsJItQUeeh3xnGN0voQ==",
+			"dev": true
 		},
 		"@babel/helper-explode-assignable-expression": {
 			"version": "7.16.7",
@@ -17588,6 +17629,7 @@
 			"version": "7.17.9",
 			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.17.9.tgz",
 			"integrity": "sha512-7cRisGlVtiVqZ0MW0/yFB4atgpGLWEHUVYnb448hZK4x+vih0YO5UoS11XIYtZYqHd0dIPMdUSv8q5K4LdMnIg==",
+			"dev": true,
 			"requires": {
 				"@babel/template": "^7.16.7",
 				"@babel/types": "^7.17.0"
@@ -17597,6 +17639,7 @@
 			"version": "7.16.7",
 			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz",
 			"integrity": "sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "^7.16.7"
 			}
@@ -17614,6 +17657,7 @@
 			"version": "7.16.7",
 			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz",
 			"integrity": "sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "^7.16.7"
 			}
@@ -17622,6 +17666,7 @@
 			"version": "7.18.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.18.0.tgz",
 			"integrity": "sha512-kclUYSUBIjlvnzN2++K9f2qzYKFgjmnmjwL4zlmU5f8ZtzgWe8s0rUPSTGy2HmK4P8T52MQsS+HTQAgZd3dMEA==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-environment-visitor": "^7.16.7",
 				"@babel/helper-module-imports": "^7.16.7",
@@ -17675,6 +17720,7 @@
 			"version": "7.18.2",
 			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.18.2.tgz",
 			"integrity": "sha512-7LIrjYzndorDY88MycupkpQLKS1AFfsVRm2k/9PtKScSy5tZq0McZTj+DiMRynboZfIqOKvo03pmhTaUgiD6fQ==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "^7.18.2"
 			}
@@ -17691,6 +17737,7 @@
 			"version": "7.16.7",
 			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.7.tgz",
 			"integrity": "sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "^7.16.7"
 			}
@@ -17721,6 +17768,7 @@
 			"version": "7.18.2",
 			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.18.2.tgz",
 			"integrity": "sha512-j+d+u5xT5utcQSzrh9p+PaJX94h++KN+ng9b9WEJq7pkUPAd61FGqhjuUEdfknb3E/uDBb7ruwEeKkIxNJPIrg==",
+			"dev": true,
 			"requires": {
 				"@babel/template": "^7.16.7",
 				"@babel/traverse": "^7.18.2",
@@ -17731,6 +17779,7 @@
 			"version": "7.17.12",
 			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.17.12.tgz",
 			"integrity": "sha512-7yykMVF3hfZY2jsHZEEgLc+3x4o1O+fYyULu11GynEUQNwB6lua+IIQn1FiJxNucd5UlyJryrwsOh8PL9Sn8Qg==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-validator-identifier": "^7.16.7",
 				"chalk": "^2.0.0",
@@ -17740,7 +17789,8 @@
 		"@babel/parser": {
 			"version": "7.18.5",
 			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.5.tgz",
-			"integrity": "sha512-YZWVaglMiplo7v8f1oMQ5ZPQr0vn7HPeZXxXWsxXJRjGVrzUFn9OxFQl1sb5wzfootjA/yChhW84BV+383FSOw=="
+			"integrity": "sha512-YZWVaglMiplo7v8f1oMQ5ZPQr0vn7HPeZXxXWsxXJRjGVrzUFn9OxFQl1sb5wzfootjA/yChhW84BV+383FSOw==",
+			"dev": true
 		},
 		"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
 			"version": "7.17.12",
@@ -18521,6 +18571,7 @@
 			"version": "7.16.7",
 			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.7.tgz",
 			"integrity": "sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==",
+			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.16.7",
 				"@babel/parser": "^7.16.7",
@@ -18531,6 +18582,7 @@
 			"version": "7.18.5",
 			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.5.tgz",
 			"integrity": "sha512-aKXj1KT66sBj0vVzk6rEeAO6Z9aiiQ68wfDgge3nHhA/my6xMM/7HGQUNumKZaoa2qUPQ5whJG9aAifsxUKfLA==",
+			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.16.7",
 				"@babel/generator": "^7.18.2",
@@ -18548,6 +18600,7 @@
 					"version": "4.1.1",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
 					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
 					}
@@ -18555,7 +18608,8 @@
 				"ms": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
 				}
 			}
 		},
@@ -19433,6 +19487,7 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
 			"integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
+			"dev": true,
 			"requires": {
 				"@jridgewell/set-array": "^1.0.0",
 				"@jridgewell/sourcemap-codec": "^1.4.10"
@@ -19441,22 +19496,26 @@
 		"@jridgewell/resolve-uri": {
 			"version": "3.0.7",
 			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.7.tgz",
-			"integrity": "sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA=="
+			"integrity": "sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==",
+			"dev": true
 		},
 		"@jridgewell/set-array": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.1.tgz",
-			"integrity": "sha512-Ct5MqZkLGEXTVmQYbGtx9SVqD2fqwvdubdps5D3djjAkgkKwT918VNOz65pEHFaYTeWcukmJmH5SwsA9Tn2ObQ=="
+			"integrity": "sha512-Ct5MqZkLGEXTVmQYbGtx9SVqD2fqwvdubdps5D3djjAkgkKwT918VNOz65pEHFaYTeWcukmJmH5SwsA9Tn2ObQ==",
+			"dev": true
 		},
 		"@jridgewell/sourcemap-codec": {
 			"version": "1.4.13",
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz",
-			"integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w=="
+			"integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==",
+			"dev": true
 		},
 		"@jridgewell/trace-mapping": {
 			"version": "0.3.13",
 			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.13.tgz",
 			"integrity": "sha512-o1xbKhp9qnIAoHJSWd6KlCZfqslL4valSF81H8ImioOAxluWYWOpWkpyktY2vnt4tbrX9XYaxovq6cgowaJp2w==",
+			"dev": true,
 			"requires": {
 				"@jridgewell/resolve-uri": "^3.0.3",
 				"@jridgewell/sourcemap-codec": "^1.4.10"
@@ -20422,8 +20481,7 @@
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
 			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"acorn-walk": {
 			"version": "6.2.0",
@@ -20644,8 +20702,7 @@
 		"apollo-server-errors": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-2.5.0.tgz",
-			"integrity": "sha512-lO5oTjgiC3vlVg2RKr3RiXIIQ5pGXBFxYGGUkKDhTud3jMIhs+gel8L8zsEjKaKxkjHhCQAA/bcEfYiKkGQIvA==",
-			"requires": {}
+			"integrity": "sha512-lO5oTjgiC3vlVg2RKr3RiXIIQ5pGXBFxYGGUkKDhTud3jMIhs+gel8L8zsEjKaKxkjHhCQAA/bcEfYiKkGQIvA=="
 		},
 		"apollo-server-express": {
 			"version": "2.26.1",
@@ -21620,6 +21677,7 @@
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
 			"integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+			"dev": true,
 			"requires": {
 				"safe-buffer": "~5.1.1"
 			}
@@ -22622,8 +22680,7 @@
 			"version": "8.8.0",
 			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz",
 			"integrity": "sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"eslint-import-resolver-node": {
 			"version": "0.3.7",
@@ -23452,7 +23509,8 @@
 		"gensync": {
 			"version": "1.0.0-beta.2",
 			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-			"integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="
+			"integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+			"dev": true
 		},
 		"get-caller-file": {
 			"version": "2.0.5",
@@ -23552,7 +23610,8 @@
 		"globals": {
 			"version": "11.12.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+			"dev": true
 		},
 		"globalthis": {
 			"version": "1.0.3",
@@ -23677,8 +23736,7 @@
 		"graphql-scalars": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/graphql-scalars/-/graphql-scalars-0.1.5.tgz",
-			"integrity": "sha512-+1nNlZO5Gvrqih7WxyDjaRoFEY0bDyQmAsIDvjjuU1vEP+Q+FNeg9AbDtSrDkI5b+RK4duapqKAXIgK7sbhiug==",
-			"requires": {}
+			"integrity": "sha512-+1nNlZO5Gvrqih7WxyDjaRoFEY0bDyQmAsIDvjjuU1vEP+Q+FNeg9AbDtSrDkI5b+RK4duapqKAXIgK7sbhiug=="
 		},
 		"graphql-subscriptions": {
 			"version": "1.2.1",
@@ -23725,8 +23783,7 @@
 		"graphql-type-json": {
 			"version": "0.2.4",
 			"resolved": "https://registry.npmjs.org/graphql-type-json/-/graphql-type-json-0.2.4.tgz",
-			"integrity": "sha512-/tq02ayMQjrG4oDFDRLLrPk0KvJXue0nVXoItBe7uAdbNXjQUu+HYCBdAmPLQoseVzUKKMzrhq2P/sfI76ON6w==",
-			"requires": {}
+			"integrity": "sha512-/tq02ayMQjrG4oDFDRLLrPk0KvJXue0nVXoItBe7uAdbNXjQUu+HYCBdAmPLQoseVzUKKMzrhq2P/sfI76ON6w=="
 		},
 		"growly": {
 			"version": "1.3.0",
@@ -25423,8 +25480,7 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
 			"integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"jest-regex-util": {
 			"version": "25.2.6",
@@ -26133,7 +26189,8 @@
 		"js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+			"dev": true
 		},
 		"js-yaml": {
 			"version": "3.13.1",
@@ -26208,7 +26265,8 @@
 		"jsesc": {
 			"version": "2.5.2",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
+			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+			"dev": true
 		},
 		"json-parse-even-better-errors": {
 			"version": "2.3.1",
@@ -26245,7 +26303,8 @@
 		"json5": {
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
+			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+			"dev": true
 		},
 		"jsonfile": {
 			"version": "4.0.0",
@@ -30139,8 +30198,7 @@
 		"ws": {
 			"version": "7.5.8",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.8.tgz",
-			"integrity": "sha512-ri1Id1WinAX5Jqn9HejiGb8crfRio0Qgu8+MtL36rlTA6RLsMdWt1Az/19A2Qij6uSHUMphEFaTKa4WG+UNHNw==",
-			"requires": {}
+			"integrity": "sha512-ri1Id1WinAX5Jqn9HejiGb8crfRio0Qgu8+MtL36rlTA6RLsMdWt1Az/19A2Qij6uSHUMphEFaTKa4WG+UNHNw=="
 		},
 		"xml-name-validator": {
 			"version": "3.0.0",

--- a/src/resources/swagger/index.yaml
+++ b/src/resources/swagger/index.yaml
@@ -84,13 +84,76 @@ paths:
         required: true
         schema:
           type: string
-    get:
+    post:
       tags:
         - Clinical Proxies
       security:
         - bearerAuth: []
       summary: Query program data from clinical service
       description: 'Query program data by ID from clinical service'
+      requestBody:
+        description: JSON object containing search filters
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                completionState:
+                  $ref: '#/components/schemas/CompletionState'
+                  default: 'all'
+                entityTypes:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/EntityName'
+                  default: []
+                donorIds:
+                  type: array
+                  items:
+                    type: number
+                  default: []
+                submitterDonorIds:
+                  type: array
+                  items:
+                    type: string
+                  default: []
+      responses:
+        '200':
+          description: 'Returns clinicalEntities[], completionStats[] & clinicalErrors[]'
+          content:
+            application/json:
+              schema:
+                type: object
+        '500':
+          description: Internal server error
+  '/clinical/program/{programId}/clinical-errors':
+    parameters:
+      - name: programId
+        description: the short name of the program
+        in: path
+        required: true
+        schema:
+          type: string
+    post:
+      tags:
+        - Clinical Proxies
+      security:
+        - bearerAuth: []
+      summary: Query program data errors from clinical service
+      description: 'Query program data errors by ID from clinical service'
+      requestBody:
+        description: JSON object containing search filters
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                donorIds:
+                  type: array
+                  items:
+                    type: number
+                  default: []
       responses:
         '200':
           description: 'Returns clinicalEntities[], completionStats[] & clinicalErrors[]'
@@ -108,13 +171,41 @@ paths:
         required: true
         schema:
           type: string
-    get:
+    post:
       tags:
         - Clinical Proxies
       security:
         - bearerAuth: []
       summary: Query donor IDs and submitter IDs matching a query on clinical service
       description: 'Query Donor IDs + Submitter IDs matching a filter from clinical service'
+      requestBody:
+        description: JSON object containing search filters
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                completionState:
+                  $ref: '#/components/schemas/CompletionState'
+                  default: 'all'
+                entityTypes:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/EntityName'
+                  default: []
+                donorIds:
+                  description: List of donor IDs or partial IDs to search for. Results will be returned for any partial matches with the input strings.
+                  type: array
+                  items:
+                    type: string
+                  default: []
+                submitterDonorIds:
+                  description: List of submitter donor IDs or partial IDs to search for. Results will be returned for any partial matches with the input strings.
+                  type: array
+                  items:
+                    type: string
+                  default: []
       responses:
         '200':
           description: 'Returns donorId[] & submitterDonorId[]'
@@ -132,13 +223,39 @@ paths:
         required: true
         schema:
           type: string
-    get:
+    post:
       tags:
         - Clinical Proxies
       security:
         - bearerAuth: []
       summary: Download a zip file with tsv files for filtered clinical data in program
       description: 'Download a zip file with tsv files for filtered clinical data in program'
+      requestBody:
+        description: JSON object containing search filters
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                completionState:
+                  $ref: '#/components/schemas/CompletionState'
+                  default: 'all'
+                entityTypes:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/EntityName'
+                  default: []
+                donorIds:
+                  type: array
+                  items:
+                    type: number
+                  default: []
+                submitterDonorIds:
+                  type: array
+                  items:
+                    type: string
+                  default: []
       responses:
         '200':
           description: 'A zip file with all program submitted data'
@@ -243,3 +360,29 @@ components:
       type: http
       scheme: bearer
       bearerFormat: JWT
+  schemas:
+    CompletionState:
+      type: string
+      enum: [all, invalid, complete, incomplete]
+
+    EntityName:
+      type: string
+      enum:
+        [
+          donor,
+          sampleRegistration,
+          specimens,
+          primaryDiagnoses,
+          familyHistory,
+          treatment,
+          treatments,
+          chemotherapy,
+          immunotherapy,
+          surgery,
+          radiation,
+          followUps,
+          hormoneTherapy,
+          exposure,
+          comorbidity,
+          biomarker,
+        ]

--- a/src/routes/clinical-proxy.ts
+++ b/src/routes/clinical-proxy.ts
@@ -98,6 +98,19 @@ router.use(
 );
 
 router.use(
+	'/program/:programId/clinical-errors',
+	createProxyMiddleware({
+		target: CLINICAL_SERVICE_ROOT,
+		pathRewrite: (pathName: string, req: Request) => {
+			const programId = req.params.programId;
+			return urlJoin('/clinical/program/', programId, '/clinical-errors');
+		},
+		onError: handleError,
+		changeOrigin: true,
+	}),
+);
+
+router.use(
 	'/program/:programId/clinical-search-results',
 	createProxyMiddleware({
 		target: CLINICAL_SERVICE_ROOT,

--- a/src/services/clinical/index.js
+++ b/src/services/clinical/index.js
@@ -155,7 +155,7 @@ const getClinicalData = async (variables, Authorization) => {
 		body: {
 			completionState,
 			entityTypes,
-			donorIds: donorIds?.map((id) => Number(id)) || [],
+			donorIds: donorIds?.map((id) => Number(id)).filter((id) => !isNaN(id)) || [],
 			submitterDonorIds,
 		},
 	})

--- a/src/services/clinical/index.js
+++ b/src/services/clinical/index.js
@@ -161,7 +161,6 @@ const getClinicalData = async (variables, Authorization) => {
 	})
 		.then(restErrorResponseHandler)
 		.then((response) => {
-			console.log('hello', response);
 			return response;
 		})
 		.then((response) => response.json());

--- a/src/services/clinical/index.js
+++ b/src/services/clinical/index.js
@@ -17,8 +17,8 @@
  * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import fetch, { Response } from 'node-fetch';
 import FormData from 'form-data';
+import fetch, { Response } from 'node-fetch';
 import urlJoin from 'url-join';
 
 import { CLINICAL_SERVICE_ROOT } from '../../config';
@@ -108,7 +108,6 @@ const getClinicalSubmissionSchemaVersion = async () => {
 	})
 		.then(restErrorResponseHandler)
 		.then((response) => response.json());
-	console.log(response.version);
 	return response.version;
 };
 
@@ -151,18 +150,15 @@ const getClinicalData = async (variables, Authorization) => {
 
 	const response = await fetch(url, {
 		method: 'post',
-		headers: { Authorization },
-		body: {
+		headers: { Authorization, 'Content-Type': 'application/json' },
+		body: JSON.stringify({
 			completionState,
 			entityTypes,
 			donorIds: donorIds?.map((id) => Number(id)).filter((id) => !isNaN(id)) || [],
 			submitterDonorIds,
-		},
+		}),
 	})
 		.then(restErrorResponseHandler)
-		.then((response) => {
-			return response;
-		})
 		.then((response) => response.json());
 
 	return response;
@@ -183,12 +179,12 @@ const getClinicalSearchResults = async (variables, Authorization) => {
 	const response = await fetch(url, {
 		method: 'post',
 		headers: { Authorization },
-		body: {
+		body: JSON.stringify({
 			completionState,
 			entityTypes,
 			donorIds,
 			submitterDonorIds,
-		},
+		}),
 	})
 		.then(restErrorResponseHandler)
 		.then((response) => response.json());
@@ -209,9 +205,9 @@ const getClinicalErrors = async (programShortName, filters, Authorization) => {
 	const response = await fetch(url, {
 		method: 'post',
 		headers: { Authorization },
-		body: {
+		body: JSON.stringify({
 			donorIds,
-		},
+		}),
 	})
 		.then(restErrorResponseHandler)
 		.then((response) => response.json());
@@ -295,7 +291,7 @@ const reopenClinicalSubmissionData = async (programShortName, versionId, Authori
 };
 
 const approveClinicalSubmissionData = async (programShortName, versionId, Authorization) => {
-	const response = await fetch(
+	await fetch(
 		`${CLINICAL_SERVICE_ROOT}/submission/program/${programShortName}/clinical/approve/${versionId}`,
 		{
 			method: 'post',

--- a/src/services/clinical/utils.ts
+++ b/src/services/clinical/utils.ts
@@ -1,0 +1,22 @@
+export type ClinicalInput = {
+	page: number;
+	pageSize: number;
+	sort: string;
+	entityTypes: string[];
+	donorIds: number[];
+	submitterDonorIds: string[];
+	completionState: string[];
+};
+/**
+ * Get common query params out of the page, pageSize, and sort filters from clinical gql requests.
+ * This string can be provided at the end of the url to provide the query parmas
+ * @param filters
+ */
+export const buildClinicalInputQueryString = (filters: ClinicalInput): string => {
+	const { page, pageSize, sort } = filters;
+
+	const pageQuery = page !== undefined ? `page=${page}` : '';
+	const pageSizeQuery = pageSize !== undefined ? `pageSize=${pageSize}` : '';
+	const sortQuery = sort !== undefined ? `sort=${sort}` : '';
+	return [pageQuery, pageSizeQuery, sortQuery].filter((query) => !!query).join('&');
+};


### PR DESCRIPTION
**Description of changes**

Updates Clinical API based on breaking changes here: https://github.com/icgc-argo/argo-clinical/pull/980

The clinical data/error/search APIs all use POST method now, with several query params moved into the request body.

This also makes the filter pagination properties useful in gql, adding them to the request to clinical.

This has been tested vs the clinical API locally but not in context in the UI. That will require some further trials after dev deploy.

**Type of Change**

- [ ] Bug
- [x] New Feature
