### PR TITLE
Fix clinicalError resolver, both nested in clinicalData and at root

### DIFF
--- a/src/constants/http.ts
+++ b/src/constants/http.ts
@@ -1,0 +1,2 @@
+export const HEADER_CONTENTTYPE = 'Content-Type';
+export const CONTENTTYPE_JSON = 'application/json';

--- a/src/schemas/Clinical/gqlTypeDefs.ts
+++ b/src/schemas/Clinical/gqlTypeDefs.ts
@@ -321,7 +321,7 @@ export default gql`
 		"""
 		Retrieve all stored Clinical Migration Errors for a program
 		"""
-		clinicalErrors(programShortName: String!, filters: ClinicalInput!): ClinicalData!
+		clinicalErrors(programShortName: String!, donorIds: [Int]): [ClinicalErrors!]!
 	}
 
 	type Mutation {

--- a/src/services/clinical/index.js
+++ b/src/services/clinical/index.js
@@ -24,6 +24,7 @@ import urlJoin from 'url-join';
 import { CLINICAL_SERVICE_ROOT } from '../../config';
 import { restErrorResponseHandler } from '../../utils/restUtils';
 
+import { CONTENTTYPE_JSON, HEADER_CONTENTTYPE } from 'constants/http';
 import { buildClinicalInputQueryString } from './utils';
 
 const getRegistrationData = async (programShortName, Authorization) => {
@@ -150,11 +151,11 @@ const getClinicalData = async (variables, Authorization) => {
 
 	const response = await fetch(url, {
 		method: 'post',
-		headers: { Authorization, 'Content-Type': 'application/json' },
+		headers: { Authorization, [HEADER_CONTENTTYPE]: CONTENTTYPE_JSON },
 		body: JSON.stringify({
 			completionState,
 			entityTypes,
-			donorIds: donorIds?.map((id) => Number(id)).filter((id) => !isNaN(id)) || [],
+			donorIds,
 			submitterDonorIds,
 		}),
 	})
@@ -178,7 +179,7 @@ const getClinicalSearchResults = async (variables, Authorization) => {
 
 	const response = await fetch(url, {
 		method: 'post',
-		headers: { Authorization },
+		headers: { Authorization, [HEADER_CONTENTTYPE]: CONTENTTYPE_JSON },
 		body: JSON.stringify({
 			completionState,
 			entityTypes,
@@ -191,23 +192,20 @@ const getClinicalSearchResults = async (variables, Authorization) => {
 	return response;
 };
 
-const getClinicalErrors = async (programShortName, filters, Authorization) => {
-	const { donorIds } = filters;
-	const queryString = buildClinicalInputQueryString(filters);
-
+const getClinicalErrors = async (programShortName, donorIds, Authorization) => {
 	const url = urlJoin(
 		CLINICAL_SERVICE_ROOT,
 		`/clinical/program/`,
 		programShortName,
-		`/clinical-errors?${queryString}`,
+		`/clinical-errors`,
 	);
 
+	const body = Array.isArray(donorIds) ? JSON.stringify({ donorIds }) : undefined;
+	console.log('body', body);
 	const response = await fetch(url, {
 		method: 'post',
-		headers: { Authorization },
-		body: JSON.stringify({
-			donorIds,
-		}),
+		headers: { Authorization, [HEADER_CONTENTTYPE]: CONTENTTYPE_JSON },
+		body,
 	})
 		.then(restErrorResponseHandler)
 		.then((response) => response.json());


### PR DESCRIPTION
**Description of changes**

GQL Resolver for ClinicalError needed to be defined in two places, once for direct query from root and then again from nested in clinicalData. This was found because the getClinicalError api funciton was broken in the previous PR, so this was fixed in a way to satisfy both.

In addition, it was found that the clinical API was not parsing the JSON bodies without the `Content-Type` header set to `application/json` so that was added to the POST requests.

**Type of Change**

- [x] Bug
- [ ] New Feature
