### PR TITLE
Program Resolver format HTTP response bug from missing properties

### DIFF
--- a/src/schemas/Program/index.js
+++ b/src/schemas/Program/index.js
@@ -247,11 +247,11 @@ const formatHttpProgram = (program) => ({
 	shortName: program.shortName,
 	description: program.description,
 	website: program.website,
-	institutions: program.programInstitutions.map((institution) => institution.name),
-	countries: program.programCountries.map((country) => country.name),
-	regions: program.processingRegions.map((region) => region.name),
-	cancerTypes: program.programCancers.map((cancer) => cancer.name),
-	primarySites: program.programPrimarySites.map((primarySite) => primarySite.name),
+	institutions: program.programInstitutions?.map((institution) => institution.name) || [],
+	countries: program.programCountries?.map((country) => country.name) || [],
+	regions: program.processingRegions?.map((region) => region.name) || [],
+	cancerTypes: program.programCancers?.map((cancer) => cancer.name) || [],
+	primarySites: program.programPrimarySites?.map((primarySite) => primarySite.name) || [],
 });
 
 const resolveProgramList = async (egoToken) => {


### PR DESCRIPTION
**Description of changes**

This change acommodates a change to the response structure of programs from Program Service.

The ProgramService is removing `processingRegions` as a program property. The http response formatting code in our program resolver assumed the presence of some fields without checking for them. Updating this code block with optional chaining and default values resolves the breaking issue.

**Type of Change**

- [x] Bug
- [ ] New Feature
