### PR TITLE
Add `has_clinical_data` to arranger metadata

### DIFF
--- a/src/resources/arranger_es_metadata.json
+++ b/src/resources/arranger_es_metadata.json
@@ -277,6 +277,12 @@
 							"show": false,
 							"active": true,
 							"type": "Aggregations"
+						},
+						{
+							"field": "has_clinical_data",
+							"show": false,
+							"active": true,
+							"type": "Aggregations"
 						}
 					]
 				},
@@ -887,6 +893,18 @@
 						"isArray": false,
 						"rangeStep": 1,
 						"type": "keyword",
+						"primaryKey": false
+					},
+					{
+						"unit": null,
+						"displayValues": {},
+						"quickSearchEnabled": false,
+						"field": "has_clinical_data",
+						"displayName": "Has Clinical Data",
+						"active": false,
+						"isArray": false,
+						"rangeStep": 1,
+						"type": "boolean",
 						"primaryKey": false
 					},
 					{


### PR DESCRIPTION
**Description of changes**

Adding `has_clinical_data` property to the arranger extended and aggs_state metadata.

**Type of Change**

- [ ] Bug
- [x] New Feature
