### PR TITLE
Prevent double response body read from error handler

### DIFF
--- a/src/services/programService/httpClient.js
+++ b/src/services/programService/httpClient.js
@@ -22,16 +22,17 @@
  * The content of Ego.proto is copied directly from: https://github.com/icgc-argo/argo-proto/blob/4e2aeda59eb48b7af20b462aef2f04ef5d0d6e7c/ProgramService.proto
  */
 
-const { PROGRAM_SERVICE_HTTP_ROOT } = require('config');
 import fetch from 'node-fetch';
-import { programServicePublicErrorResponseHandler } from '../../utils/restUtils';
+
+import { PROGRAM_SERVICE_HTTP_ROOT } from '../../config';
+import { restErrorResponseHandler } from '../../utils/restUtils';
 
 const getProgramPublicFields = async (programShortName) => {
 	const url = `${PROGRAM_SERVICE_HTTP_ROOT}/public/program?name=${programShortName}`;
 	const response = await fetch(url, {
 		method: 'get',
 	})
-		.then(programServicePublicErrorResponseHandler)
+		.then(restErrorResponseHandler)
 		.then((response) => response.json());
 	return response;
 };

--- a/src/utils/restUtils.ts
+++ b/src/utils/restUtils.ts
@@ -23,10 +23,12 @@ import { Response } from 'node-fetch';
 
 import logger from './logger';
 
-const errorResponseHandler = async (response: Response, message: string) => {
+export const restErrorResponseHandler = async (response: Response) => {
 	// Generic handle 5xx errors
 	if (response.status >= 500 && response.status <= 599) {
-		logger.debug(`Server 5xx response: ${message}`);
+		const message = await response.text();
+		const status = response.status;
+		logger.debug(`Server ${status} response: ${message}`);
 		throw new ApolloError(message); // will return Apollo code INTERNAL_SERVER_ERROR
 	}
 
@@ -48,17 +50,4 @@ const errorResponseHandler = async (response: Response, message: string) => {
 		default:
 			return response;
 	}
-};
-
-/*
-convert the REST status codes to GQL errors, or return the response if passing
-*/
-export const restErrorResponseHandler = async (response: Response) => {
-	const responseBody = await response.text();
-	return await errorResponseHandler(response, responseBody);
-};
-
-export const programServicePublicErrorResponseHandler = async (response: Response) => {
-	const responseBody = await get(response, 'statusText');
-	return await errorResponseHandler(response, responseBody);
 };


### PR DESCRIPTION
**Description of changes**

Simplify error handling to make more consistent throughout.
Correct a bug introduced by restUtils refactoring that caused a duplicate read of response body.


**Type of Change**

- [x] Bug
- [ ] New Feature
