### PR TITLE
Download Clinical Data by File API Updates

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -118,7 +118,6 @@ const init = async () => {
 	]);
 
 	const server = new ArgoApolloServer({
-		// @ts-ignore ApolloServer type is missing this for some reason
 		schema: mergeSchemas({
 			schemas,
 		}),
@@ -187,7 +186,6 @@ const init = async () => {
 	app.use('/api-docs', apiDocRouter());
 
 	app.listen(PORT, () => {
-		// @ts-ignore ApolloServer type is missing graphqlPath for some reason
 		logger.info(`🚀 Server ready at http://localhost:${PORT}${server.graphqlPath}`);
 		logger.info(`🚀 Rest API doc available at http://localhost:${PORT}/api-docs`);
 	});

--- a/src/resources/arranger_es_metadata.json
+++ b/src/resources/arranger_es_metadata.json
@@ -897,10 +897,10 @@
 					},
 					{
 						"unit": null,
-						"displayValues": {},
+						"displayValues": { "false": "Not Available", "true": "Available" },
 						"quickSearchEnabled": false,
 						"field": "has_clinical_data",
-						"displayName": "Has Clinical Data",
+						"displayName": "Clinical Data",
 						"active": false,
 						"isArray": false,
 						"rangeStep": 1,

--- a/src/resources/swagger/index.yaml
+++ b/src/resources/swagger/index.yaml
@@ -70,12 +70,12 @@ paths:
             schema:
               type: object
               properties:
-                fileIds:
-                  description: Array of file IDs. Must have at least one item.
+                objectIds:
+                  description: Array of files' object IDs. Must have at least one item.
                   type: array
                   items:
                     type: string
-                  example: ['FI123']
+                  example: ['33eb128f-fcc5-5a1a-bb86-d6b3f96ed7b0']
       responses:
         '200':
           description: 'A zip file with all program submitted data'

--- a/src/routes/clinical/clinical-api.ts
+++ b/src/routes/clinical/clinical-api.ts
@@ -44,7 +44,7 @@ const createClincalApiRouter = async (esClient: Client, egoClient: EgoClient) =>
 	 *  ************************************** */
 
 	const FileDownloadRequestBody = zod.object({
-		fileIds: zod.string().array().min(1),
+		objectIds: zod.string().array().min(1),
 	});
 
 	router.use('/donors/data-for-files', async (req: AuthenticatedRequest, res) => {
@@ -78,8 +78,8 @@ const createClincalApiRouter = async (esClient: Client, egoClient: EgoClient) =>
 		// 2. retrieve related files from ES
 		const query = esb
 			.requestBodySearch()
-			.size(body.fileIds.length)
-			.query(esb.boolQuery().must([esb.termsQuery('file_id', body.fileIds)]));
+			.size(body.objectIds.length)
+			.query(esb.boolQuery().must([esb.termsQuery('object_id', body.objectIds)]));
 
 		const filesResponse = await esClient
 			.search<EsHits<EsFileCentricDocument>>({


### PR DESCRIPTION
**Description of changes**

- Cleanup text in Arranger mapping for `has_clinical_data` field
- Switch to `object_id` to identify files for the download clinical data by file endpoint
    - Small change greatly simplifies changes required on UI
