### PR TITLE
#691/ Adding data center gql type, query and resolver

### DIFF
--- a/src/schemas/Program/index.js
+++ b/src/schemas/Program/index.js
@@ -96,6 +96,22 @@ const typeDefs = gql`
 		countries: [String]!
 	}
 
+	type DataCenter {
+		id: ID
+		shortName: String!
+		name: String
+		organization: String
+		email: String
+		uiUrl: String
+		gatewayUrl: String
+		analysisSongCode: String
+		analysisSongUrl: String
+		analysisScoreUrl: String
+		submissionSongCode: String
+		submissionSongUrl: String
+		submissionScoreUrl: String
+	}
+
 	input ProgramUserInput {
 		email: String!
 		firstName: String!
@@ -169,6 +185,11 @@ const typeDefs = gql`
 		joinProgramInvite(id: ID!): JoinProgramInvite
 
 		programOptions: ProgramOptions!
+
+		"""
+		retrieve all DataCenters
+		"""
+		dataCenters: [DataCenter]
 	}
 
 	type Mutation {
@@ -271,6 +292,11 @@ const resolveHTTPProgram = async (programShortName) => {
 	return response ? formatHttpProgram(response) : null;
 };
 
+const resolveDataCenterList = async (egoToken) => {
+	const response = await programService.listDataCenters(egoToken);
+	return response || null;
+};
+
 const programServicePrivateFields = [
 	'commitmentDonors',
 	'submittedDonors',
@@ -354,6 +380,10 @@ const resolvers = {
 			return response ? grpcToGql(joinProgramDetails) : null;
 		},
 		programOptions: () => ({}),
+		dataCenters: async (obj, args, context, info) => {
+			const { egoToken } = context;
+			return resolveDataCenterList(egoToken);
+		},
 	},
 	Mutation: {
 		createProgram: async (obj, args, context, info) => {

--- a/src/services/programService/httpClient.js
+++ b/src/services/programService/httpClient.js
@@ -27,7 +27,7 @@ import fetch from 'node-fetch';
 import { PROGRAM_SERVICE_HTTP_ROOT } from '../../config';
 import { restErrorResponseHandler } from '../../utils/restUtils';
 
-const getProgramPublicFields = async (programShortName) => {
+export const getProgramPublicFields = async (programShortName) => {
 	const url = `${PROGRAM_SERVICE_HTTP_ROOT}/public/program?name=${programShortName}`;
 	const response = await fetch(url, {
 		method: 'get',
@@ -37,4 +37,15 @@ const getProgramPublicFields = async (programShortName) => {
 	return response;
 };
 
-export { getProgramPublicFields };
+export const listDataCenters = async (jwt) => {
+	const url = `${PROGRAM_SERVICE_HTTP_ROOT}/datacenters`;
+	const response = await fetch(url, {
+		method: 'get',
+		headers: {
+			Authorization: `Bearer ${jwt}`,
+		},
+	})
+		.then(restErrorResponseHandler)
+		.then((response) => response.json());
+	return response;
+};

--- a/src/services/programService/index.js
+++ b/src/services/programService/index.js
@@ -46,4 +46,6 @@ export default {
 	removeUser: grpc.removeUser,
 
 	getProgramPublicFields: http.getProgramPublicFields,
+
+	listDataCenters: http.listDataCenters,
 };


### PR DESCRIPTION
Refer to ticket #691 

Plateform API is able to make a gql query to dataCenters. Use this query for testing:

`{
  dataCenters {
    name
    shortName
    id
    organization
    email
    uiUrl
    gatewayUrl
    analysisSongCode
    analysisSongUrl
    analysisScoreUrl
    submissionSongCode
    submissionSongUrl
    submissionScoreUrl
  }
}`

jwt token is needed for this query.

**Ticket Checklist**
- [x] Create DataCenter type in gql schema
- [x]  Add dataCenters query
- [x]  Create dataCenters query resolver that will retrieve list of all data centers from ProgramService
- [x]  Add listDataCenters method to the program service HTTP client that will fetch data centers from ProgramService

**Type of Change**

- [ ] Bug
- [x] New Feature
