### PR TITLE
#692 Add data center name filter to dataCenter gql query

### DIFF
--- a/src/schemas/Program/index.js
+++ b/src/schemas/Program/index.js
@@ -189,7 +189,7 @@ const typeDefs = gql`
 		"""
 		retrieve all DataCenters
 		"""
-		dataCenters: [DataCenter]
+		dataCenters(shortName: String): [DataCenter]
 	}
 
 	type Mutation {
@@ -292,11 +292,6 @@ const resolveHTTPProgram = async (programShortName) => {
 	return response ? formatHttpProgram(response) : null;
 };
 
-const resolveDataCenterList = async (egoToken) => {
-	const response = await programService.listDataCenters(egoToken);
-	return response || null;
-};
-
 const programServicePrivateFields = [
 	'commitmentDonors',
 	'submittedDonors',
@@ -382,7 +377,9 @@ const resolvers = {
 		programOptions: () => ({}),
 		dataCenters: async (obj, args, context, info) => {
 			const { egoToken } = context;
-			return resolveDataCenterList(egoToken);
+			const shortName = get(args, 'shortName', null);
+			const response = await programService.listDataCenters(shortName, egoToken);
+			return response || null;
 		},
 	},
 	Mutation: {

--- a/src/services/programService/httpClient.js
+++ b/src/services/programService/httpClient.js
@@ -27,6 +27,13 @@ import fetch from 'node-fetch';
 import { PROGRAM_SERVICE_HTTP_ROOT } from '../../config';
 import { restErrorResponseHandler } from '../../utils/restUtils';
 
+//get DataCenter by Program short name handler
+const getDataCenterByShortName = (shortName, dataCenterResponse) => {
+	return dataCenterResponse.filter((dataCenterObject) => {
+		return dataCenterObject.shortName === shortName;
+	});
+};
+
 export const getProgramPublicFields = async (programShortName) => {
 	const url = `${PROGRAM_SERVICE_HTTP_ROOT}/public/program?name=${programShortName}`;
 	const response = await fetch(url, {
@@ -37,7 +44,7 @@ export const getProgramPublicFields = async (programShortName) => {
 	return response;
 };
 
-export const listDataCenters = async (jwt) => {
+export const listDataCenters = async (shortName, jwt) => {
 	const url = `${PROGRAM_SERVICE_HTTP_ROOT}/datacenters`;
 	const response = await fetch(url, {
 		method: 'get',
@@ -46,6 +53,9 @@ export const listDataCenters = async (jwt) => {
 		},
 	})
 		.then(restErrorResponseHandler)
-		.then((response) => response.json());
+		.then((response) => response.json())
+		.then((response) => {
+			return shortName ? getDataCenterByShortName(shortName, response) : response;
+		});
 	return response;
 };


### PR DESCRIPTION
Add an optional parameter (shortName) to the dataCenter query, where resolver will filter out the dataCenter data with the shortName.

 
**Ticket Check List**
- [x] Add a function getDataCenterByShortName to the program service http client

- [x] Add an optional parameter for the dataCenter query to filter by data center short name.

- [x] Update the dataCenters resolver to accept the short name filter, and fetch a single data center when provided using the new http client function

**Testing Query**
use the following query to test result. 

Note: There are two dataCenter objects now with the shrotName, DC1 and DC2. 

`{
  dataCenters(shortName: "DC1") {
    id
    shortName
    name
    organization
    email
    uiUrl
    gatewayUrl
    analysisSongCode
    analysisSongUrl
    analysisScoreUrl
    submissionSongCode
    submissionSongUrl
    submissionScoreUrl
  }
}`

**Type of Change**

- [ ] Bug
- [x] New Feature
