### PR TITLE
Add `dataCenter` to GQL `Program` type

### DIFF
--- a/src/schemas/Program/index.js
+++ b/src/schemas/Program/index.js
@@ -72,6 +72,7 @@ const typeDefs = gql`
 		regions: [String]
 		cancerTypes: [String]
 		primarySites: [String]
+		dataCenter: DataCenter
 
 		membershipType: MembershipType
 
@@ -284,6 +285,7 @@ const programServicePrivateFields = [
 	'genomicDonors',
 	'membershipType',
 	'users',
+	'dataCenter',
 ];
 
 const resolvers = {

--- a/src/services/programService/httpClient.js
+++ b/src/services/programService/httpClient.js
@@ -25,12 +25,12 @@
 import fetch from 'node-fetch';
 import urljoin from 'url-join';
 
+import logger from 'utils/logger';
+
 import { PROGRAM_SERVICE_HTTP_ROOT } from '../../config';
 import { restErrorResponseHandler } from '../../utils/restUtils';
 
 import authorizationHeader from './utils/authorizationHeader';
-
-import logger from 'utils/logger';
 
 //data formatters
 const formatPublicProgram = (program) => ({


### PR DESCRIPTION
Add dataCenter property to gql Program type. Update private field list, making query with dataCenter field a private Program route.

**Type of Change**

- [ ] Bug
- [x] New Feature

**Testing Query**
Now GET program and listPrograms can fetch dataCenter info.
1. for GET program:
```
{
  program(shortName: "ALEXIS-CA") {

    dataCenter {
      id
      shortName
      name
      uiUrl
      gatewayUrl
   
    }
  }
}
```
2. listPrograms
```
{
  programs {

    dataCenter {
      id
      shortName
      name
      uiUrl
      gatewayUrl
    }
  }
}
```
