### PR TITLE
Hotfix - Add `/profile` handler to storage-api proxy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "server",
-	"version": "3.42.0",
+	"version": "3.42.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "server",
-			"version": "3.42.0",
+			"version": "3.42.1",
 			"license": "ISC",
 			"dependencies": {
 				"@arranger/server": "^2.18.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "server",
-	"version": "3.42.0",
+	"version": "3.42.1",
 	"description": "",
 	"main": "index.js",
 	"scripts": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -101,6 +101,7 @@ export const DEV_RECAPTCHA_DISABLED = process.env.DEV_RECAPTCHA_DISABLED === 'tr
 
 // File Storage API
 export const MAX_FILE_DOWNLOAD_SIZE = Number(process.env.MAX_FILE_DOWNLOAD_SIZE) || 5000000; // 5MB
+export const STORAGE_API_PROFILE = process.env.STORAGE_API_PROFILE || 'az';
 
 // TSV download configs
 export const DEFAULT_TSV_STREAM_CHUNK_SIZE =

--- a/src/routes/file-storage-api/index.ts
+++ b/src/routes/file-storage-api/index.ts
@@ -20,7 +20,7 @@
 import { Client } from '@elastic/elasticsearch';
 import express, { Router } from 'express';
 import urljoin from 'url-join';
-import { ADVERTISED_HOST } from 'config';
+import { ADVERTISED_HOST, STORAGE_API_PROFILE } from 'config';
 import downloadProxy, { downloadFile } from './handlers/downloadHandler';
 import createEntitiesHandler from './handlers/entitiesHandler';
 import createEntitiesIdHandler from './handlers/entitiesIdHandler';
@@ -88,6 +88,14 @@ export default async ({
 			scoreAuthClient,
 		}),
 	);
+	router.get('/profile', (_req, res) => {
+		// TODO: This is a temorary fix, this will not work for federated data!
+
+		// This will tell the score client which storage profile to use. While we have only one rdpc we can simply
+		// report the correct profile for our setup. We will need the download client to report the correct profile
+		// per object it is downloading once there are multiple RDPCs to support.
+		res.send(STORAGE_API_PROFILE);
+	});
 
 	return router;
 };


### PR DESCRIPTION
**Description of changes**

Temporary fix to help score-client work with azure downloads.

This will work so long as we only download from a single RDPC, or all RDPCs use the same storage profile. Once this is not the case then the score-client will need a mechanism to request the download profile per download... we can't support a single profile for all downloads.
