### PR TITLE
Endpoint to download clinical data for a filtered query

### DIFF
--- a/src/resources/swagger/index.yaml
+++ b/src/resources/swagger/index.yaml
@@ -102,8 +102,8 @@ paths:
         - Clinical API
       security:
         - bearerAuth: []
-      summary: Download clinical data for all available files from filter.
-      description: Download clinical data for all available files from filter.
+      summary: Download clinical data associated with the donors for all files. A SQON filter can be provided to restrict the data retrieved to the files returned by a specific query.
+      description: Download clinical data associated with the donors for all files. A SQON filter can be provided to restrict the data retrieved to the files returned by a specific query.
       responses:
         '200':
           description: 'A zip file with all program submitted data'

--- a/src/resources/swagger/index.yaml
+++ b/src/resources/swagger/index.yaml
@@ -89,7 +89,7 @@ paths:
         '500':
           description: Internal server error
 
-  '/clinical/api/donors/data-for-all-files':
+  '/clinical/api/donors/data-for-query':
     parameters:
       - name: filter
         description: JSON filter following the SQON spec

--- a/src/resources/swagger/index.yaml
+++ b/src/resources/swagger/index.yaml
@@ -53,7 +53,7 @@ paths:
                 type: string
         '500':
           description: Internal server error
-          
+
   '/clinical/api/donors/data-for-files':
     post:
       tags:
@@ -88,6 +88,35 @@ paths:
           description: The error message indicates something wrong with the request
         '500':
           description: Internal server error
+
+  '/clinical/api/donors/data-for-all-files':
+    parameters:
+      - name: filter
+        description: JSON filter following the SQON spec
+        in: query
+        required: false
+        schema:
+          type: string
+    post:
+      tags:
+        - Clinical API
+      security:
+        - bearerAuth: []
+      summary: Download clinical data for all available files from filter.
+      description: Download clinical data for all available files from filter.
+      responses:
+        '200':
+          description: 'A zip file with all program submitted data'
+          content:
+            application/zip:
+              schema:
+                type: string
+                format: binary
+        '400':
+          description: The error message indicates something wrong with the request
+        '500':
+          description: Internal server error
+
   '/clinical/proxy/program/{programId}/all-clinical-data':
     parameters:
       - name: programId

--- a/src/routes/clinical/arranger.ts
+++ b/src/routes/clinical/arranger.ts
@@ -1,0 +1,95 @@
+import { ADVERTISED_HOST } from 'config';
+import { get } from 'lodash';
+import fetch from 'node-fetch';
+import urljoin from 'url-join';
+
+const url = urljoin(ADVERTISED_HOST, '/graphql');
+
+const hitsQuery = `
+  query hitsQuery($filters: JSON, $first: Int) {
+    file {
+      hits(filters: $filters, first: $first) {
+        edges {
+          node {
+            donors {
+              hits {
+                edges {
+                  node {
+                    donor_id
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }`;
+
+const totalQuery = `
+  query totalQuery($filters: JSON) {
+    file {
+      hits(filters: $filters) {
+        total
+      }
+    }
+  }`;
+
+function makeRequest({ query, variables }: { query: string; variables: Record<string, unknown> }) {
+	return JSON.stringify({
+		query,
+		variables,
+	});
+}
+
+function createQueryClient({ requestConfig }: { requestConfig: Record<string, unknown> }) {
+	return async ({ query }: { query: string }) => {
+		try {
+			const response = await fetch(url, {
+				...requestConfig,
+				body: query,
+			});
+			const data = await response.json();
+			return data;
+		} catch (error) {
+			console.error(`Failed to query server`, error);
+		}
+	};
+}
+
+async function queryArranger({
+	requestFilter,
+	egoJwt,
+}: {
+	requestFilter: Record<string, unknown>;
+	egoJwt: string;
+}): Promise<string[]> {
+	const requestConfig = {
+		method: 'post',
+		headers: { Authorization: `Bearer ${egoJwt}`, 'Content-Type': 'application/json' },
+	};
+	try {
+		const queryClient = createQueryClient({ requestConfig });
+		const queryVariables = { filters: requestFilter };
+		// need two queries to pass "total" into hits filter to specify offset range
+		const totalData = await queryClient({ query: makeRequest({ query: totalQuery, variables: queryVariables }) });
+		const totalHits = get(totalData, 'data.file.hits.total');
+		const hits = await queryClient({
+			query: makeRequest({ query: hitsQuery, variables: { ...queryVariables, first: totalHits } }),
+		});
+
+		const donorEdgePath = 'data.file.hits.edges';
+		const records = get(hits, donorEdgePath, undefined);
+
+		if (!records) {
+			return [];
+		} else {
+			const donorIdPath = 'node.donors.hits.edges[0].node.donor_id';
+			return Array.from(new Set(records.map((record: Record<string, unknown>) => get(record, donorIdPath))));
+		}
+	} catch (error) {
+		throw Error(`Query Arranger failed.`, error);
+	}
+}
+
+export default queryArranger;

--- a/src/routes/clinical/arranger.ts
+++ b/src/routes/clinical/arranger.ts
@@ -58,6 +58,14 @@ function createQueryClient({ requestConfig }: { requestConfig: Record<string, un
 	};
 }
 
+/**
+ * Queries Arranger instance for all donor ids (no pagination), optionally filtered by input param
+ * Use case: retrieving all donor ids to send download file request to clinical service
+ *
+ * @param param.requestFilter - SQON filter
+ * @param param.egoJwt - User Ego token
+ * @returns Unique set of donor ids
+ */
 async function queryArranger({
 	requestFilter,
 	egoJwt,
@@ -71,6 +79,7 @@ async function queryArranger({
 	};
 	try {
 		const queryClient = createQueryClient({ requestConfig });
+		// SQON Builder is not Arrangerv2 compatible
 		const queryVariables = { filters: requestFilter };
 		// need two queries to pass "total" into hits filter to specify offset range
 		const queryResponse = await queryClient({ query: makeRequest({ query: totalQuery, variables: queryVariables }) });

--- a/src/routes/clinical/arranger.ts
+++ b/src/routes/clinical/arranger.ts
@@ -73,8 +73,8 @@ async function queryArranger({
 		const queryClient = createQueryClient({ requestConfig });
 		const queryVariables = { filters: requestFilter };
 		// need two queries to pass "total" into hits filter to specify offset range
-		const totalData = await queryClient({ query: makeRequest({ query: totalQuery, variables: queryVariables }) });
-		const totalHits = get(totalData, 'data.file.hits.total');
+		const queryResponse = await queryClient({ query: makeRequest({ query: totalQuery, variables: queryVariables }) });
+		const totalHits = get(queryResponse, 'data.file.hits.total');
 		const hits = await queryClient({
 			query: makeRequest({ query: hitsQuery, variables: { ...queryVariables, first: totalHits } }),
 		});

--- a/src/routes/clinical/arranger.ts
+++ b/src/routes/clinical/arranger.ts
@@ -1,7 +1,8 @@
-import { ADVERTISED_HOST } from 'config';
 import { get } from 'lodash';
 import fetch from 'node-fetch';
 import urljoin from 'url-join';
+
+import { ADVERTISED_HOST } from 'config';
 
 const url = urljoin(ADVERTISED_HOST, '/graphql');
 

--- a/src/routes/clinical/arranger.ts
+++ b/src/routes/clinical/arranger.ts
@@ -70,7 +70,7 @@ async function queryArranger({
 	requestFilter,
 	egoJwt,
 }: {
-	requestFilter: Record<string, unknown>;
+	requestFilter: Record<string, {}[]>;
 	egoJwt: string;
 }): Promise<string[]> {
 	const requestConfig = {
@@ -80,7 +80,18 @@ async function queryArranger({
 	try {
 		const queryClient = createQueryClient({ requestConfig });
 		// SQON Builder is not Arrangerv2 compatible
-		const queryVariables = { filters: requestFilter };
+		const filters = {
+			op: 'and',
+			content: [
+				{
+					op: 'in',
+					content: { fieldName: 'has_clinical_data', value: ['true'] },
+				},
+				...requestFilter.content,
+			],
+		};
+		const queryVariables = { filters };
+
 		// need two queries to pass "total" into hits filter to specify offset range
 		const queryResponse = await queryClient({ query: makeRequest({ query: totalQuery, variables: queryVariables }) });
 		const totalHits = get(queryResponse, 'data.file.hits.total');

--- a/src/routes/clinical/arranger.ts
+++ b/src/routes/clinical/arranger.ts
@@ -85,9 +85,9 @@ async function queryArranger({
 			content: [
 				{
 					op: 'in',
-					content: { fieldName: 'has_clinical_data', value: ['true'] },
+					content: { field: 'has_clinical_data', value: 'true' },
 				},
-				...requestFilter.content,
+				requestFilter,
 			],
 		};
 		const queryVariables = { filters };

--- a/src/routes/clinical/clinical-api.ts
+++ b/src/routes/clinical/clinical-api.ts
@@ -161,19 +161,19 @@ const createClincalApiRouter = async (esClient: Client, egoClient: EgoClient) =>
 		}
 	});
 
-	router.use('/donors/data-for-all-files', async (req: AuthenticatedRequest, res) => {
+	router.use('/donors/data-for-query', async (req: AuthenticatedRequest, res) => {
 		try {
 			// Grab requester JWT
 			const { scopes, userId, authenticated, egoJwt } = req.auth;
 
 			if (!authenticated) {
-				logger.debug(`[clinical-routes] /donors/data-for-all-files: Request not authenticated.`);
+				logger.debug(`[clinical-routes] /donors/data-for-query: Request not authenticated.`);
 				return res.status(401).json({ error: 'Must be authenticated to access resource.' });
 			}
 			const hasDaco = hasDacoAccess(scopes);
 			if (!hasDaco) {
 				logger.debug(
-					`[clinical-routes] /donors/data-for-all-files: User ${userId} requesting clinical data without DACO access`,
+					`[clinical-routes] /donors/data-for-query: User ${userId} requesting clinical data without DACO access`,
 				);
 				return res.status(403).json({ error: 'Users require DACO approval to access clinical data.' });
 			}
@@ -210,7 +210,7 @@ const createClincalApiRouter = async (esClient: Client, egoClient: EgoClient) =>
 				});
 			}
 		} catch (e) {
-			logger.error(`[clinical-routes] /donors/data-for-all-files: unexpected error occurred: ${e}`);
+			logger.error(`[clinical-routes] /donors/data-for-query: unexpected error occurred: ${e}`);
 			return res.status(500).json({
 				error: e.message || 'An unexpected error occurred retrieving clinical file data.',
 			});


### PR DESCRIPTION
**Link to Issue**
- icgc-argo/roadmap#1056

**Description of changes**

- adds support for "download all files" from file repo
- uses Arranger for inbuilt permission management
- queries arranger GQL endpoint on self, can't target Arranger api directly as it's not exported from module (using old version of Arranger)
- performant even with 12k files selected, looks like we have internal Arranger code already handling large selections https://github.com/overture-stack/arranger/blob/legacy/modules/mapping-utils/src/resolveHits.js#L38


**Type of Change**

- [ ] Bug
- [ ] New Feature
