### PR TITLE
Datacenters are public field for program queries

### DIFF
--- a/src/schemas/Program/index.js
+++ b/src/schemas/Program/index.js
@@ -43,14 +43,7 @@ const resolvePublicSingleProgram = async (programShortName) => {
 	return response || null;
 };
 
-const programServicePrivateFields = [
-	'commitmentDonors',
-	'submittedDonors',
-	'genomicDonors',
-	'membershipType',
-	'users',
-	'dataCenter',
-];
+const programServicePrivateFields = ['commitmentDonors', 'submittedDonors', 'genomicDonors', 'membershipType', 'users'];
 
 const resolvers = {
 	ProgramOptions: {


### PR DESCRIPTION
**Description of changes**

Datacenters are now available in the public program queries: https://github.com/icgc-argo/program-service/pull/454

This change uses the public query for datacenter data. This allows for datacenters to be shown on the public Program Details page of the platform UI.